### PR TITLE
Fixing unreliable `RuntimeEventListenerSpec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logging wrong duration in the first simulation hour [#705](https://github.com/ie3-institute/simona/issues/705)
 - Fixed some compiler warnings [#657](https://github.com/ie3-institute/simona/issues/657)
 - Fixing false negative in ref system voltage validation [#706](https://github.com/ie3-institute/simona/issues/706)
+- Fixing randomly failing test in `RuntimeEventListenerSpec` etc. [#709](https://github.com/ie3-institute/simona/issues/709)
 
 ## [3.0.0] - 2023-08-07
 

--- a/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerKafkaSpec.scala
+++ b/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerKafkaSpec.scala
@@ -128,13 +128,14 @@ class RuntimeEventListenerKafkaSpec
       forAll(cases) { case (event, expectedMsg) =>
         listenerRef ! event
 
-        val records: List[SimonaEndMessage] =
-          eventually(timeout(20 seconds), interval(1 second)) {
+        eventually(timeout(20 seconds), interval(1 second)) {
+          val records =
             testConsumer.poll((1 second) toJava).asScala.map(_.value()).toList
-          }
 
-        records should have length 1
-        records should contain(expectedMsg)
+          records should have length 1
+          records should contain(expectedMsg)
+        }
+
       }
 
     }

--- a/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerSpec.scala
+++ b/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerSpec.scala
@@ -147,8 +147,12 @@ class RuntimeEventListenerSpec
         ),
       )
 
+      val loggingTestKit = LoggingTestKit.empty
+        // logger name for ActorContext loggers (ctx.log) is the class name
+        .withLoggerName(RuntimeEventListener.getClass.getName)
+
       events.foreach { case (event, level, msg) =>
-        LoggingTestKit.empty
+        loggingTestKit
           .withLogLevel(level)
           .withMessageContains(msg)
           .expect {

--- a/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerSpec.scala
+++ b/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerSpec.scala
@@ -47,30 +47,27 @@ class RuntimeEventListenerSpec
     with PrivateMethodTester {
 
   // global variables
-  val eventQueue = new LinkedBlockingQueue[RuntimeEvent]()
   val startDateTimeString = "2011-01-01 00:00:00"
   val endTick = 3600
   val duration = 10805000
-  val errMsg =
-    "Und wenn du lange in einen Abgrund blickst, blickt der Abgrund auch in dich hinein"
+  val errMsg = "testing error msg"
 
-  // to change for Ready event test cases
   val currentTick = 0
-
-  // build the listener
-  private val listenerRef = spawn(
-    RuntimeEventListener(
-      SimonaConfig.Simona.Runtime.Listener(
-        None,
-        None,
-      ),
-      Some(eventQueue),
-      startDateTimeString,
-    )
-  )
 
   "A runtime event listener" must {
     "add a valid runtime event to the blocking queue for further processing" in {
+      val eventQueue = new LinkedBlockingQueue[RuntimeEvent]()
+
+      val listenerRef = spawn(
+        RuntimeEventListener(
+          SimonaConfig.Simona.Runtime.Listener(
+            None,
+            None,
+          ),
+          Some(eventQueue),
+          startDateTimeString,
+        )
+      )
 
       //  valid runtime events
       val eventsToQueue: Seq[RuntimeEvent] = List(
@@ -96,6 +93,17 @@ class RuntimeEventListenerSpec
     }
 
     "return valid log messages for each status event" in {
+
+      val listenerRef = spawn(
+        RuntimeEventListener(
+          SimonaConfig.Simona.Runtime.Listener(
+            None,
+            None,
+          ),
+          None,
+          startDateTimeString,
+        )
+      )
 
       def calcTime(curTick: Long): String = {
         TimeUtil.withDefaults.toString(

--- a/src/test/scala/edu/ie3/simona/model/participant/load/LoadModelScalingSpec.scala
+++ b/src/test/scala/edu/ie3/simona/model/participant/load/LoadModelScalingSpec.scala
@@ -340,7 +340,7 @@ class LoadModelScalingSpec extends UnitSpec with TableDrivenPropertyChecks {
         getRelativeDifference(
           quantile95,
           targetMaximumPower,
-        ) should be < Percent(1d)
+        ) should be < Percent(2d)
       }
 
       "correctly account for the scaling factor when targeting at maximum power" in {


### PR DESCRIPTION
Closes #709

I also fixed some other unreliable tests and/or improved unspecific failure messages