### PR TITLE
Fixing `RuntimeEventListenerSpec` by separating out logging test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed provision of controllingEms within buildParticipantToActorRef [#841](https://github.com/ie3-institute/simona/issues/841)
 - Simulation stopping at unhandled messages in `DBFSAlgorithm` [#821](https://github.com/ie3-institute/simona/issues/821)
 - Not stopping correctly on failed power flow if configured  to stop [#800](https://github.com/ie3-institute/simona/issues/800)
+- Finally fixing `RuntimeEventListenerSpec` [#849](https://github.com/ie3-institute/simona/issues/849)
 
 ## [3.0.0] - 2023-08-07
 

--- a/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerKafkaSpec.scala
+++ b/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerKafkaSpec.scala
@@ -34,7 +34,8 @@ class RuntimeEventListenerKafkaSpec
     with UnitSpec
     with KafkaSpecLike
     with GivenWhenThen
-    with TableDrivenPropertyChecks {
+    with TableDrivenPropertyChecks
+    with RuntimeTestData {
   private var testConsumer: KafkaConsumer[Bytes, SimonaEndMessage] = _
 
   private implicit lazy val resultFormat: RecordFormat[SimonaEndMessage] =
@@ -50,8 +51,6 @@ class RuntimeEventListenerKafkaSpec
     (0 until testTopic.partitions).map(
       new TopicPartition(testTopic.name, _)
     )
-
-  private val startDateTimeString = "2011-01-01T00:00:00Z"
 
   private val mockSchemaRegistryUrl = "mock://unused:8081"
 
@@ -104,15 +103,14 @@ class RuntimeEventListenerKafkaSpec
 
       When("receiving the SimonaEndMessages")
 
-      val errMsg = "Test error msg"
       val cases = Table(
         ("event", "expectedMsg"),
         (
-          Done(1800L, 3L, errorInSim = false),
+          Done(1800L, duration, errorInSim = false),
           SimonaEndMessage(runId, 1, error = false),
         ),
         (
-          Done(3600L, 3L, errorInSim = true),
+          Done(3600L, duration, errorInSim = true),
           SimonaEndMessage(runId, 1, error = true),
         ),
         (Error(errMsg), SimonaEndMessage(runId, -1, error = true)),

--- a/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerLoggingSpec.scala
+++ b/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerLoggingSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * © 2020. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
+
+package edu.ie3.simona.event.listener
+
+import com.typesafe.config.ConfigValueFactory
+import edu.ie3.simona.config.SimonaConfig
+import edu.ie3.simona.event.RuntimeEvent.{
+  CheckWindowPassed,
+  Done,
+  Error,
+  InitComplete,
+  Initializing,
+  PowerFlowFailed,
+  Ready,
+  Simulating,
+}
+import edu.ie3.simona.test.common.UnitSpec
+import edu.ie3.simona.util.TickUtil._
+import edu.ie3.util.TimeUtil
+import org.apache.pekko.actor.testkit.typed.scaladsl.{
+  ActorTestKit,
+  LoggingTestKit,
+  ScalaTestWithActorTestKit,
+}
+import org.slf4j.event.Level
+
+/** Logging must be tested in a separate test, since LoggingTestKit can still
+  * receives logs from test that it was not enabled for
+  */
+class RuntimeEventListenerLoggingSpec
+    extends ScalaTestWithActorTestKit(
+      ActorTestKit.ApplicationTestConfig.withValue(
+        // Timeout for LoggingTestKit via TestKitSettings
+        // Log message sometimes seem to take a while until caught by the test kit
+        "org.apache.pekko.actor.testkit.typed.filter-leeway",
+        ConfigValueFactory.fromAnyRef("30s"),
+      )
+    )
+    with UnitSpec
+    with RuntimeTestData {
+
+  "A runtime event listener" must {
+    "return valid log messages for each status event" in {
+
+      val listenerRef = spawn(
+        RuntimeEventListener(
+          SimonaConfig.Simona.Runtime.Listener(
+            None,
+            None,
+          ),
+          None,
+          startDateTimeString,
+        )
+      )
+
+      def calcTime(curTick: Long): String = {
+        TimeUtil.withDefaults.toString(
+          curTick.toDateTime(
+            TimeUtil.withDefaults.toZonedDateTime(startDateTimeString)
+          )
+        )
+      }
+
+      // Fail two power flows, should get counted
+      listenerRef ! PowerFlowFailed
+      listenerRef ! PowerFlowFailed
+
+      val events = Seq(
+        (
+          Initializing,
+          Level.INFO,
+          "Initializing Agents and Services for Simulation ... ",
+        ),
+        (
+          InitComplete(0L),
+          Level.INFO,
+          s"Initialization complete. (duration: 0h : 0m : 0s )",
+        ),
+        (
+          Ready(currentTick, 0L),
+          Level.INFO,
+          s"Switched from 'Simulating' to 'Ready'. Last simulated time: ${calcTime(currentTick)}.",
+        ),
+        (
+          Simulating(currentTick, endTick),
+          Level.INFO,
+          s"Simulating from ${calcTime(currentTick)} until ${calcTime(endTick)}.",
+        ),
+        (
+          CheckWindowPassed(currentTick, 0L),
+          Level.INFO,
+          s"Simulation until ${calcTime(currentTick)} completed.",
+        ),
+        (
+          Done(endTick, duration, errorInSim = false),
+          Level.INFO,
+          s"Simulation completed with \u001b[0;32mSUCCESS (Failed PF: 2)\u001b[0;0m in time step ${calcTime(endTick)}. Total runtime: 3h : 0m : 5s ",
+        ),
+        (
+          Error(errMsg),
+          Level.ERROR,
+          errMsg,
+        ),
+      )
+
+      val loggingTestKit = LoggingTestKit.empty
+        // logger name for ActorContext loggers (ctx.log) is the class name
+        .withLoggerName(RuntimeEventListener.getClass.getName)
+
+      events.foreach { case (event, level, msg) =>
+        loggingTestKit
+          .withLogLevel(level)
+          .withMessageContains(msg)
+          .expect {
+            listenerRef ! event
+          }
+      }
+
+    }
+  }
+}

--- a/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerSpec.scala
+++ b/src/test/scala/edu/ie3/simona/event/listener/RuntimeEventListenerSpec.scala
@@ -6,49 +6,24 @@
 
 package edu.ie3.simona.event.listener
 
-import org.apache.pekko.actor.testkit.typed.scaladsl.{
-  ActorTestKit,
-  LoggingTestKit,
-  ScalaTestWithActorTestKit,
-}
-import com.typesafe.config.ConfigValueFactory
 import edu.ie3.simona.config.SimonaConfig
 import edu.ie3.simona.event.RuntimeEvent
 import edu.ie3.simona.event.RuntimeEvent.{
-  CheckWindowPassed,
   Done,
   Error,
-  InitComplete,
   Initializing,
-  PowerFlowFailed,
   Ready,
   Simulating,
 }
 import edu.ie3.simona.test.common.UnitSpec
-import edu.ie3.simona.util.TickUtil._
-import edu.ie3.util.TimeUtil
-import org.slf4j.event.Level
+import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 
 import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
 
 class RuntimeEventListenerSpec
-    extends ScalaTestWithActorTestKit(
-      ActorTestKit.ApplicationTestConfig.withValue(
-        // Timeout for LoggingTestKit via TestKitSettings
-        // Log message sometimes seem to take a while until caught by the test kit
-        "org.apache.pekko.actor.testkit.typed.filter-leeway",
-        ConfigValueFactory.fromAnyRef("30s"),
-      )
-    )
-    with UnitSpec {
-
-  // global variables
-  val startDateTimeString = "2011-01-01T00:00:00Z"
-  val endTick = 3600
-  val duration = 10805000
-  val errMsg = "testing error msg"
-
-  val currentTick = 0
+    extends ScalaTestWithActorTestKit
+    with UnitSpec
+    with RuntimeTestData {
 
   "A runtime event listener" must {
     "add a valid runtime event to the blocking queue for further processing" in {
@@ -88,82 +63,5 @@ class RuntimeEventListenerSpec
       }
     }
 
-    "return valid log messages for each status event" in {
-
-      val listenerRef = spawn(
-        RuntimeEventListener(
-          SimonaConfig.Simona.Runtime.Listener(
-            None,
-            None,
-          ),
-          None,
-          startDateTimeString,
-        )
-      )
-
-      def calcTime(curTick: Long): String = {
-        TimeUtil.withDefaults.toString(
-          curTick.toDateTime(
-            TimeUtil.withDefaults.toZonedDateTime(startDateTimeString)
-          )
-        )
-      }
-
-      // Fail two power flows, should get counted
-      listenerRef ! PowerFlowFailed
-      listenerRef ! PowerFlowFailed
-
-      val events = Seq(
-        (
-          Initializing,
-          Level.INFO,
-          "Initializing Agents and Services for Simulation ... ",
-        ),
-        (
-          InitComplete(0L),
-          Level.INFO,
-          s"Initialization complete. (duration: 0h : 0m : 0s )",
-        ),
-        (
-          Ready(currentTick, 0L),
-          Level.INFO,
-          s"Switched from 'Simulating' to 'Ready'. Last simulated time: ${calcTime(currentTick)}.",
-        ),
-        (
-          Simulating(currentTick, endTick),
-          Level.INFO,
-          s"Simulating from ${calcTime(currentTick)} until ${calcTime(endTick)}.",
-        ),
-        (
-          CheckWindowPassed(currentTick, 0L),
-          Level.INFO,
-          s"Simulation until ${calcTime(currentTick)} completed.",
-        ),
-        (
-          Done(endTick, duration, errorInSim = false),
-          Level.INFO,
-          s"Simulation completed with \u001b[0;32mSUCCESS (Failed PF: 2)\u001b[0;0m in time step ${calcTime(endTick)}. Total runtime: 3h : 0m : 5s ",
-        ),
-        (
-          Error(errMsg),
-          Level.ERROR,
-          errMsg,
-        ),
-      )
-
-      val loggingTestKit = LoggingTestKit.empty
-        // logger name for ActorContext loggers (ctx.log) is the class name
-        .withLoggerName(RuntimeEventListener.getClass.getName)
-
-      events.foreach { case (event, level, msg) =>
-        loggingTestKit
-          .withLogLevel(level)
-          .withMessageContains(msg)
-          .expect {
-            listenerRef ! event
-          }
-      }
-
-    }
   }
 }

--- a/src/test/scala/edu/ie3/simona/event/listener/RuntimeTestData.scala
+++ b/src/test/scala/edu/ie3/simona/event/listener/RuntimeTestData.scala
@@ -1,0 +1,18 @@
+/*
+ * © 2024. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
+
+package edu.ie3.simona.event.listener
+
+trait RuntimeTestData {
+
+  protected val startDateTimeString: String = "2011-01-01T00:00:00Z"
+  protected val endTick: Long = 3600
+  protected val duration: Long = 10805000
+  protected val errMsg: String = "testing error msg"
+
+  protected val currentTick: Long = 0
+
+}


### PR DESCRIPTION
Resolves #849 

Should run a bunch (read: a lot) of times in CI for us to make sure that it's actually fixed. 