### PR TITLE
Simplified methods to values in ThermalHouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated AUTHORS.md [#905](https://github.com/ie3-institute/simona/issues/905)
 - Rewrote BMModelTest from groovy to scala [#646](https://github.com/ie3-institute/simona/issues/646)
 - Refactoring EM messages [#947](https://github.com/ie3-institute/simona/issues/947)
+- Simplifying ThermalHouse [#940](https://github.com/ie3-institute/simona/issues/940)
 
 ### Fixed
 - Removed a repeated line in the documentation of vn_simona config [#658](https://github.com/ie3-institute/simona/issues/658)

--- a/src/main/scala/edu/ie3/simona/model/thermal/ThermalHouse.scala
+++ b/src/main/scala/edu/ie3/simona/model/thermal/ThermalHouse.scala
@@ -212,7 +212,6 @@ final case class ThermalHouse(
     currentInnerTemperature + temperatureChange
   }
 
-
   /** Update the current state of the house
     *
     * @param tick
@@ -280,7 +279,7 @@ final case class ThermalHouse(
       innerTemperature,
       ambientTemperature,
       artificialDuration,
-    )  / artificialDuration
+    ) / artificialDuration
     val resultingQDot = qDotExternal - loss
     if (
       resultingQDot < zeroMW && !isInnerTemperatureTooLow(

--- a/src/main/scala/edu/ie3/simona/model/thermal/ThermalHouse.scala
+++ b/src/main/scala/edu/ie3/simona/model/thermal/ThermalHouse.scala
@@ -201,14 +201,19 @@ final case class ThermalHouse(
   ): Temperature = {
     val thermalEnergyGain = thermalPower * duration
 
+    // thermal energy loss due to the deviation between outside and inside temperature
     val thermalEnergyLoss = ethLosses.calcThermalEnergyChange(
       currentInnerTemperature,
       ambientTemperature,
       duration,
     )
 
-    val temperatureChange = (thermalEnergyGain - thermalEnergyLoss) / ethCapa
+    val energyChange = thermalEnergyGain - thermalEnergyLoss
 
+    // temperature change calculated from energy change(WattHours) and thermal capacity(Joules per Kelvin)
+    val temperatureChange = energyChange / ethCapa
+
+    // return value new inner temperature
     currentInnerTemperature + temperatureChange
   }
 

--- a/src/main/scala/edu/ie3/util/scala/quantities/ThermalConductance.scala
+++ b/src/main/scala/edu/ie3/util/scala/quantities/ThermalConductance.scala
@@ -33,7 +33,7 @@ final class ThermalConductance private (
     *   Time duration
     * @return
     */
-  def thermalConductanceToEnergy(
+  def calcThermalEnergyChange(
       temperatureInner: Temperature,
       temperatureOuter: Temperature,
       time: squants.Time,

--- a/src/test/scala/edu/ie3/simona/model/thermal/ThermalHouseSpec.scala
+++ b/src/test/scala/edu/ie3/simona/model/thermal/ThermalHouseSpec.scala
@@ -56,23 +56,18 @@ class ThermalHouseSpec extends UnitSpec with HpInputTestData {
       val thermalHouseTest = thermalHouse(18, 22)
       val innerTemperature = Temperature(20, Celsius)
 
-      val thermalEnergyGain =
-        thermalHouseTest.calcThermalEnergyGain(Kilowatts(100), Seconds(3600))
-      val thermalEnergyLoss = thermalHouseTest.calcThermalEnergyLoss(
+      val thermalEnergyGain = KilowattHours(100)
+      val thermalEnergyLoss = thermalHouseTest.ethLosses.calcThermalEnergyChange(
         innerTemperature,
         Temperature(10, Celsius),
         Seconds(3600),
       )
-      val thermalEnergyChange = thermalHouseTest.calcThermalEnergyChange(
-        thermalEnergyGain,
-        thermalEnergyLoss,
-      )
-      val innerTemperatureChange =
-        thermalHouseTest.calcInnerTemperatureChange(thermalEnergyChange)
-      val newInnerTemperature = thermalHouseTest.calcNewInnerTemperature(
-        innerTemperature,
-        innerTemperatureChange,
-      )
+      val thermalEnergyChange = thermalEnergyGain - thermalEnergyLoss
+
+      val innerTemperatureChange = thermalEnergyChange/thermalHouseTest.ethCapa
+
+      val newInnerTemperature = innerTemperature + innerTemperatureChange
+
 
       thermalEnergyGain should approximate(KilowattHours(100))
       thermalEnergyLoss should approximate(KilowattHours(10))

--- a/src/test/scala/edu/ie3/simona/model/thermal/ThermalHouseSpec.scala
+++ b/src/test/scala/edu/ie3/simona/model/thermal/ThermalHouseSpec.scala
@@ -57,17 +57,18 @@ class ThermalHouseSpec extends UnitSpec with HpInputTestData {
       val innerTemperature = Temperature(20, Celsius)
 
       val thermalEnergyGain = KilowattHours(100)
-      val thermalEnergyLoss = thermalHouseTest.ethLosses.calcThermalEnergyChange(
-        innerTemperature,
-        Temperature(10, Celsius),
-        Seconds(3600),
-      )
+      val thermalEnergyLoss =
+        thermalHouseTest.ethLosses.calcThermalEnergyChange(
+          innerTemperature,
+          Temperature(10, Celsius),
+          Seconds(3600),
+        )
       val thermalEnergyChange = thermalEnergyGain - thermalEnergyLoss
 
-      val innerTemperatureChange = thermalEnergyChange/thermalHouseTest.ethCapa
+      val innerTemperatureChange =
+        thermalEnergyChange / thermalHouseTest.ethCapa
 
       val newInnerTemperature = innerTemperature + innerTemperatureChange
-
 
       thermalEnergyGain should approximate(KilowattHours(100))
       thermalEnergyLoss should approximate(KilowattHours(10))

--- a/src/test/scala/edu/ie3/simona/model/thermal/ThermalHouseSpec.scala
+++ b/src/test/scala/edu/ie3/simona/model/thermal/ThermalHouseSpec.scala
@@ -52,31 +52,6 @@ class ThermalHouseSpec extends UnitSpec with HpInputTestData {
       }
     }
 
-    "Calculation of thermal energy change and new inner temperature is performed correctly" in {
-      val thermalHouseTest = thermalHouse(18, 22)
-      val innerTemperature = Temperature(20, Celsius)
-
-      val thermalEnergyGain = KilowattHours(100)
-      val thermalEnergyLoss =
-        thermalHouseTest.ethLosses.calcThermalEnergyChange(
-          innerTemperature,
-          Temperature(10, Celsius),
-          Seconds(3600),
-        )
-      val thermalEnergyChange = thermalEnergyGain - thermalEnergyLoss
-
-      val innerTemperatureChange =
-        thermalEnergyChange / thermalHouseTest.ethCapa
-
-      val newInnerTemperature = innerTemperature + innerTemperatureChange
-
-      thermalEnergyGain should approximate(KilowattHours(100))
-      thermalEnergyLoss should approximate(KilowattHours(10))
-      thermalEnergyChange should approximate(KilowattHours(90))
-      innerTemperatureChange should approximate(Kelvin(9.0))
-      newInnerTemperature should approximate(Celsius(29.0))
-    }
-
     "Comprising function to calculate new inner temperature works as expected" in {
       val thermalHouseTest = thermalHouse(18, 22)
       val thermalPower = Kilowatts(100)

--- a/src/test/scala/edu/ie3/util/quantities/ThermalConductanceSpec.scala
+++ b/src/test/scala/edu/ie3/util/quantities/ThermalConductanceSpec.scala
@@ -33,7 +33,7 @@ class ThermalConductanceSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return Energy when multiplied by Temperature in Kelvin and Time" in {
-    WattsPerKelvin(1000).thermalConductanceToEnergy(
+    WattsPerKelvin(1000).calcThermalEnergyChange(
       Kelvin(10),
       Kelvin(0),
       Hours(5),
@@ -41,7 +41,7 @@ class ThermalConductanceSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return Energy when multiplied by Temperature in Celsius and Time" in {
-    WattsPerKelvin(1000).thermalConductanceToEnergy(
+    WattsPerKelvin(1000).calcThermalEnergyChange(
       Celsius(10),
       Celsius(0),
       Hours(5),


### PR DESCRIPTION
Resolves #940 

Changed the methods `calcInnerTemperatureChange`, `calcThermalEnergyChange `and `calcThermalEnergyGain` to values `thermalEnergyLoss`, `thermalEnergyGain`, `temperatureChange`.

`calcInnerTemperatureChange `and `calcNewInnerTemperature `were put together in `val temperatureChange`

`thermalConductanceToEnergy` was changed to `calcThermalEnergyChange`

`def calcThermalEnergyLoss` was removed and is instead calculated in value `thermalEnergyLoss`