### PR TITLE
Added Marius Staudt to reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
   - sebastian-peter
   - danielfeismann
   - jo-bao
+  - staudtMarius
   ignore:
     - dependency-name: org.scalatest:scalatest_2.13
       versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update/enhance config documentation [#1013](https://github.com/ie3-institute/simona/issues/1013)
 - Create `CITATION.cff` [#1035](https://github.com/ie3-institute/simona/issues/1035)
 - Introduce ThermalDemandWrapper [#1049](https://github.com/ie3-institute/simona/issues/1049)
+- Added Marius Staudt to list of reviewers [#1057](https://github.com/ie3-institute/simona/issues/1057)
 
 ### Changed
 - Adapted to changed data source in PSDM [#435](https://github.com/ie3-institute/simona/issues/435)


### PR DESCRIPTION
This pull request includes updates to the `.github/dependabot.yml` and `CHANGELOG.md` files to add Marius Staudt as a reviewer.

Reviewer updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R15): Added Marius Staudt to the list of reviewers.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR45): Added Marius Staudt to the list of reviewers in the changelog.