### PR TITLE
Fixing SonarQube QG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
           ./gradlew sonar \
           -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }} \
           -Dsonar.host.url=${{ vars.SONAR_HOST_URL }} \
-          -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+          -Dsonar.login=${{ secrets.SONAR_TOKEN }} \
+          -Dsonar.qualitygate.wait=true
 
           BASE_SONAR_STATUS_URL="${{ vars.SONAR_HOST_URL }}/api/qualitygates/project_status?projectKey=${{ vars.SONAR_PROJECT_KEY }}"
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,25 +72,6 @@ jobs:
           -Dsonar.login=${{ secrets.SONAR_TOKEN }} \
           -Dsonar.qualitygate.wait=true
 
-          BASE_SONAR_STATUS_URL="${{ vars.SONAR_HOST_URL }}/api/qualitygates/project_status?projectKey=${{ vars.SONAR_PROJECT_KEY }}"
-          
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            SONAR_STATUS_URL="${BASE_SONAR_STATUS_URL}&pullRequest=${{ github.event.pull_request.number }}"
-          else
-            branch_name="${{ env.branch_name }}"
-            ENCODED_BRANCH_NAME=$(printf %s "$branch_name" | jq -sRr @uri)
-            SONAR_STATUS_URL="${BASE_SONAR_STATUS_URL}&branch=${ENCODED_BRANCH_NAME}"
-          fi
-
-          echo "Requesting quality gate status from: $SONAR_STATUS_URL"
-          QUALITY_GATE_STATUS=$(curl -s -u "${{ secrets.SONAR_TOKEN }}:" "$SONAR_STATUS_URL" | jq -r '.projectStatus.status')
-
-          echo "Quality Gate Status: $QUALITY_GATE_STATUS"
-          if [ "$QUALITY_GATE_STATUS" != "OK" ]; then
-            echo "Quality Gate failed!"
-            exit 1
-          fi
-
       #Deployment
       - name: Deploy
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor thermal calcRelevantData [#1051](https://github.com/ie3-institute/simona/issues/1051)
 - Removed Deployment stage from Jenkinsfile [#1063](https://github.com/ie3-institute/simona/issues/1063)
 - Prepare 'ChpModelSpec' and 'CylindricalThermalStorageSpec' for Storage without storageVolumeLvlMin [#1012](https://github.com/ie3-institute/simona/issues/1012)
+- Fixed SonarQube quality gate using the correct parameter '-Dsonar.qualitygate.wait=true' [#1072](https://github.com/ie3-institute/simona/issues/1072)
 
 ### Fixed
 - Fix rendering of references in documentation [#505](https://github.com/ie3-institute/simona/issues/505)


### PR DESCRIPTION
This pull request includes a small but important change to the CI workflow configuration in the `.github/workflows/ci.yml` file. The change ensures that the build process waits for the SonarQube quality gate to complete before proceeding.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL72-R73): Added the `-Dsonar.qualitygate.wait=true` parameter to the SonarQube analysis command to enforce waiting for the quality gate results.