### PR TITLE
Operating `PvModel` with data validity duration based on the next tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `RuntimeConfig` [#1172](https://github.com/ie3-institute/simona/issues/1172)
 - Renamed some methods and variables within `ThermalGrid` and `ThermalHouse` [#1193](https://github.com/ie3-institute/simona/issues/1193)
 - Replaced Java Durations with Scala Durations [#1068](https://github.com/ie3-institute/simona/issues/1068)
+- Operate `PvModel` with data validity duration based on the next, not the last tick [#1208](https://github.com/ie3-institute/simona/issues/1208)
 
 ### Fixed
 - Fix rendering of references in documentation [#505](https://github.com/ie3-institute/simona/issues/505)

--- a/src/main/scala/edu/ie3/simona/agent/participant/ParticipantAgent.scala
+++ b/src/main/scala/edu/ie3/simona/agent/participant/ParticipantAgent.scala
@@ -760,6 +760,7 @@ abstract class ParticipantAgent[
   protected def createCalcRelevantData(
       baseStateData: ParticipantModelBaseStateData[PD, CD, MS, M],
       tick: Long,
+      nextDataTick: Option[Long],
   ): CD
 
   protected def handleFlexCtrl(

--- a/src/main/scala/edu/ie3/simona/agent/participant/ParticipantAgentFundamentals.scala
+++ b/src/main/scala/edu/ie3/simona/agent/participant/ParticipantAgentFundamentals.scala
@@ -685,11 +685,13 @@ protected trait ParticipantAgentFundamentals[
 
     implicit val startDateTime: ZonedDateTime = baseStateData.startDate
 
-    val relevantData =
-      createCalcRelevantData(
-        baseStateData,
-        tick,
-      )
+    val nextDataTick = baseStateData.foreseenDataTicks.values.flatten.minOption
+
+    val relevantData = createCalcRelevantData(
+      baseStateData,
+      tick,
+      nextDataTick,
+    )
 
     val lastState = getLastOrInitialStateData(baseStateData, tick)
 
@@ -736,9 +738,11 @@ protected trait ParticipantAgentFundamentals[
         s"Received $flexCtrl, but participant agent is not in EM mode"
       )
     )
+    val nextDataTick = baseStateData.foreseenDataTicks.values.flatten.minOption
     val relevantData = createCalcRelevantData(
       baseStateData,
       flexCtrl.tick,
+      nextDataTick,
     )
     val lastState = getLastOrInitialStateData(baseStateData, flexCtrl.tick)
 
@@ -871,8 +875,10 @@ protected trait ParticipantAgentFundamentals[
       scheduler: ActorRef,
       nodalVoltage: squants.Dimensionless,
   ): FSM.State[AgentState, ParticipantStateData[PD]] = {
+    val nextDataTick = baseStateData.foreseenDataTicks.values.flatten.minOption
+
     val calcRelevantData =
-      createCalcRelevantData(baseStateData, currentTick)
+      createCalcRelevantData(baseStateData, currentTick, nextDataTick)
 
     val updatedState =
       updateState(

--- a/src/main/scala/edu/ie3/simona/agent/participant/evcs/EvcsAgentFundamentals.scala
+++ b/src/main/scala/edu/ie3/simona/agent/participant/evcs/EvcsAgentFundamentals.scala
@@ -208,6 +208,7 @@ protected trait EvcsAgentFundamentals
         EvcsModel,
       ],
       tick: Long,
+      nextDataTick: Option[Long],
   ): EvcsRelevantData = {
     // always only take arrivals for the current tick
     // or empty sequence if none arrived
@@ -494,8 +495,10 @@ protected trait EvcsAgentFundamentals
       ],
   ): FSM.State[AgentState, ParticipantStateData[ComplexPower]] = {
 
+    val nextDataTick =
+      modelBaseStateData.foreseenDataTicks.values.flatten.minOption
     val relevantData =
-      createCalcRelevantData(modelBaseStateData, tick)
+      createCalcRelevantData(modelBaseStateData, tick, nextDataTick)
 
     val lastState = getLastOrInitialStateData(modelBaseStateData, tick)
 
@@ -549,7 +552,7 @@ protected trait EvcsAgentFundamentals
   }
 
   /** Determine a reply on a
-    * [[edu.ie3.simona.agent.participant.ParticipantAgent.RequestAssetPowerMessage]]
+    * [[edu.ie3.simona.agent.participant2.ParticipantAgent.RequestAssetPowerMessage]]
     * by looking up the detailed simulation results, averaging them and
     * returning the equivalent state transition.
     *

--- a/src/main/scala/edu/ie3/simona/agent/participant/hp/HpAgentFundamentals.scala
+++ b/src/main/scala/edu/ie3/simona/agent/participant/hp/HpAgentFundamentals.scala
@@ -155,7 +155,8 @@ trait HpAgentFundamentals
     /* Determine needed information */
     val voltage =
       getAndCheckNodalVoltage(baseStateData, tick)
-    val relevantData = createCalcRelevantData(baseStateData, tick)
+    val nextDataTick = baseStateData.foreseenDataTicks.values.flatten.minOption
+    val relevantData = createCalcRelevantData(baseStateData, tick, nextDataTick)
 
     val modelState = baseStateData.stateDataStore.last(tick) match {
       case Some((lastTick, _)) if lastTick == tick =>
@@ -233,7 +234,9 @@ trait HpAgentFundamentals
     /* Determine needed information */
     val voltage =
       getAndCheckNodalVoltage(baseStateData, currentTick)
-    val relevantData = createCalcRelevantData(baseStateData, currentTick)
+    val nextDataTick = baseStateData.foreseenDataTicks.values.flatten.minOption
+    val relevantData =
+      createCalcRelevantData(baseStateData, currentTick, nextDataTick)
 
     /* Determine the next state */
     val updatedState =
@@ -405,6 +408,7 @@ trait HpAgentFundamentals
         HpModel,
       ],
       tick: Long,
+      nextDataTick: Option[Long],
   ): HpRelevantData = {
     /* extract weather data from secondary data, which should have been requested and received before */
     val weatherData =

--- a/src/main/scala/edu/ie3/simona/agent/participant/storage/StorageAgentFundamentals.scala
+++ b/src/main/scala/edu/ie3/simona/agent/participant/storage/StorageAgentFundamentals.scala
@@ -181,6 +181,7 @@ trait StorageAgentFundamentals
         StorageModel,
       ],
       tick: Long,
+      nextDataTick: Option[Long],
   ): StorageRelevantData =
     StorageRelevantData(tick)
 

--- a/src/main/scala/edu/ie3/simona/agent/participant/wec/WecAgentFundamentals.scala
+++ b/src/main/scala/edu/ie3/simona/agent/participant/wec/WecAgentFundamentals.scala
@@ -192,6 +192,7 @@ protected trait WecAgentFundamentals
         WecModel,
       ],
       tick: Long,
+      nextDataTick: Option[Long],
   ): WecRelevantData = {
     // take the last weather data, not necessarily the one for the current tick:
     // we might receive flex control messages for irregular ticks
@@ -334,12 +335,13 @@ protected trait WecAgentFundamentals
   ): FSM.State[AgentState, ParticipantStateData[ComplexPower]] = {
     val voltage =
       getAndCheckNodalVoltage(baseStateData, currentTick)
+    val nextDataTick = baseStateData.foreseenDataTicks.values.flatten.minOption
 
-    val relevantData =
-      createCalcRelevantData(
-        baseStateData,
-        currentTick,
-      )
+    val relevantData = createCalcRelevantData(
+      baseStateData,
+      currentTick,
+      nextDataTick,
+    )
 
     val result = baseStateData.model.calculatePower(
       currentTick,

--- a/src/main/scala/edu/ie3/simona/model/participant/PvModel.scala
+++ b/src/main/scala/edu/ie3/simona/model/participant/PvModel.scala
@@ -138,11 +138,12 @@ final case class PvModel private (
     val eTotal = eDifS + eBeamS + eRefS
 
     val irraditionSTC = yieldSTC * duration
-    calcOutput(
+    val out = calcOutput(
       eTotal,
       data.dateTime,
       irraditionSTC,
     )
+    out
   }
 
   /** Calculates the position of the earth in relation to the sun (day angle)

--- a/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
@@ -252,7 +252,7 @@ class EmAgentIT
 
         /* TICK 0
          LOAD: 0.269 kW
-         PV:  -5.842 kW
+         PV:  -5.945 kW
          STORAGE: SOC 0 %
          -> charge with 5 kW
          -> remaining -0.573 kW
@@ -264,8 +264,8 @@ class EmAgentIT
           0,
           weatherService.ref.toClassic,
           WeatherData(
-            WattsPerSquareMeter(200d),
-            WattsPerSquareMeter(100d),
+            WattsPerSquareMeter(80d),
+            WattsPerSquareMeter(220d),
             Celsius(0d),
             MetersPerSecond(0d),
           ),
@@ -277,7 +277,7 @@ class EmAgentIT
             emResult.getInputModel shouldBe emInput.getUuid
             emResult.getTime shouldBe 0L.toDateTime
             emResult.getP should equalWithTolerance(
-              -0.00057340027059.asMegaWatt
+              -0.000676282069474.asMegaWatt
             )
             emResult.getQ should equalWithTolerance(
               0.0000882855367033.asMegaVar
@@ -542,7 +542,7 @@ class EmAgentIT
 
         /* TICK 0
          LOAD: 0.269 kW
-         PV:  -5.842 kW
+         PV:  -5.945 kW
          Heat pump: off, can be turned on or stay off
          -> set point ~3.5 kW (bigger than 50 % rated apparent power): turned on
          -> remaining -0.723 kW
@@ -555,8 +555,8 @@ class EmAgentIT
             0,
             weatherService.ref.toClassic,
             WeatherData(
-              WattsPerSquareMeter(200d),
-              WattsPerSquareMeter(100d),
+              WattsPerSquareMeter(80d),
+              WattsPerSquareMeter(220d),
               Celsius(0d),
               MetersPerSecond(0d),
             ),
@@ -569,7 +569,7 @@ class EmAgentIT
             emResult.getInputModel shouldBe emInput.getUuid
             emResult.getTime shouldBe 0.toDateTime
             emResult.getP should equalWithTolerance(
-              -0.0007234002705905523.asMegaWatt
+              -0.000826282069474174.asMegaWatt
             )
             emResult.getQ should equalWithTolerance(
               0.0010731200407782782.asMegaVar

--- a/src/test/scala/edu/ie3/simona/agent/participant/ParticipantAgentMock.scala
+++ b/src/test/scala/edu/ie3/simona/agent/participant/ParticipantAgentMock.scala
@@ -27,7 +27,6 @@ import edu.ie3.simona.agent.participant.statedata.{
 }
 import edu.ie3.simona.agent.state.AgentState
 import edu.ie3.simona.agent.state.AgentState.Idle
-import edu.ie3.simona.config.SimonaConfig
 import edu.ie3.simona.config.RuntimeConfig.BaseRuntimeConfig
 import edu.ie3.simona.event.notifier.NotifierConfig
 import edu.ie3.simona.exceptions.agent.InvalidRequestException
@@ -312,6 +311,7 @@ class ParticipantAgentMock(
         ],
       ],
       tick: Long,
+      nextDataTick: Option[Long],
   ): FixedRelevantData.type =
     FixedRelevantData
 


### PR DESCRIPTION
Resolves #1208

The data validty duration (duration in which the current tick is valid) is now based on the interval "current tick -> next tick" (as it should), and not anymore based on "last tick -> current tick". 