### PR TITLE
Showing full stacktrace on test failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix test timeouts for all tests [#1222](https://github.com/ie3-institute/simona/issues/1222)
 - Fix handling of states in `ParticipantModelShell` [#1228](https://github.com/ie3-institute/simona/issues/1228)
 - Fix input data handling in `ParticipantModel` [#1237](https://github.com/ie3-institute/simona/issues/1237)
+- Show full stacktrace of failing tests with `gradle test` [#1245](https://github.com/ie3-institute/simona/issues/1245)
 
 ### Removed
 - Removed `SimonaListerner` and related code [#1205](https://github.com/ie3-institute/simona/issues/1205)

--- a/gradle/scripts/tests.gradle
+++ b/gradle/scripts/tests.gradle
@@ -3,6 +3,7 @@ test {
     includeEngines 'scalatest'
     testLogging {
       events("skipped", "failed")
+      exceptionFormat("full")
     }
   }
 }


### PR DESCRIPTION
Resolves #1245 

This should make debugging of failed GHA runs a lot easier.