### PR TITLE
Testwise update of gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ apply from: scriptsLocation + 'scoverage.gradle' // scoverage scala code coverag
 apply from: scriptsLocation + 'deploy.gradle'
 apply from: scriptsLocation + 'semVer.gradle'
 apply from: scriptsLocation + 'mavenCentralPublish.gradle'
-apply from: scriptsLocation + 'branchName.gradle' // checks naming scheme of branches
+apply from: scriptsLocation + 'branchName.gradle' // checks naming scheme of branch
 
 configurations {
   scalaCompilerPlugin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This pull request includes an update to the Gradle wrapper properties file to use a newer version of Gradle.

* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3): Updated the `distributionUrl` to use Gradle version 8.13 instead of 8.10.