### PR TITLE
Changed Order of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
@@ -59,12 +65,6 @@ jobs:
         env:
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: bash scripts/run-version-check.sh
-
-      - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: 17
 
       - name: Build Project
         run: ./gradlew --refresh-dependencies clean assemble spotlessCheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made some methods of `PvModel` static [#1217](https://github.com/ie3-institute/simona/issues/1217)
 - FlexOptions types in `FlexibilityMessage` [#1306](https://github.com/ie3-institute/simona/issues/1306)
 - Isolate solar radiation calculations of PvModel to its own object [#1327](https://github.com/ie3-institute/simona/issues/1327)
+- Reorganized CI order [#1333](https://github.com/ie3-institute/simona/issues/1333)
 
 ### Fixed
 - Fix rendering of references in documentation [#505](https://github.com/ie3-institute/simona/issues/505)


### PR DESCRIPTION
Closes #1333 

This pull request includes changes to the CI workflow configuration and updates to the `CHANGELOG.md` file. The most important changes are the reorganization of the CI steps and the addition of a new entry to the changelog.

CI Workflow Configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR34-R39): Moved the Java setup step earlier in the workflow to ensure it is available before running version checks and building the project. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR34-R39) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL63-L68)

Changelog Update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR174): Added an entry to document the reorganization of the CI order.