### PR TITLE
Added CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Reviewers for Dependabot PRs
+build.gradle  @sebastian-peter  @danielfeismann  @t-ober  @jo-bao  @staudtMarius
+
+# Reviewers for CI/CD related PRs
+.github/workflows/  @sebastian-peter  @PhilippSchmelter

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Reviewers for Dependabot PRs
-build.gradle  @sebastian-peter  @danielfeismann  @t-ober  @jo-bao  @staudtMarius
+build.gradle  @sebastian-peter  @danielfeismann @staudtMarius
 
 # Reviewers for CI/CD related PRs
 .github/workflows/  @sebastian-peter  @PhilippSchmelter

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,6 @@ updates:
     time: "04:00"
   open-pull-requests-limit: 10
   target-branch: dev
-  reviewers:
-  - t-ober
-  - sebastian-peter
-  - danielfeismann
-  - jo-bao
-  - staudtMarius
   ignore:
     - dependency-name: org.scalatest:scalatest_2.13
       versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added congestion detection [#1186](https://github.com/ie3-institute/simona/issues/1186)
+- Added `CODEOWNERS` file [#1387](https://github.com/ie3-institute/simona/issues/1387)
 
 ## Changed
 - Upgraded `scala2` to `scala3` [#53](https://github.com/ie3-institute/simona/issues/53)


### PR DESCRIPTION
Closes #1387 

This pull request introduces a `CODEOWNERS` file to specify reviewers for different types of pull requests, removes redundant reviewer configuration from `dependabot.yml`, and updates the `CHANGELOG.md` to reflect the addition of the `CODEOWNERS` file.

### Code ownership and reviewer configuration:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R5): Added a `CODEOWNERS` file to define reviewers for Dependabot and CI/CD-related pull requests.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L10-L15): Removed the redundant `reviewers` configuration, as this is now handled by the `CODEOWNERS` file.

### Documentation update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11): Updated to include the addition of the `CODEOWNERS` file under the "Added" section.