### PR TITLE
Cleaning up dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed CFF-Version [#1464](https://github.com/ie3-institute/simona/issues/1464)
 - Fixed handleInput of `ProfileLoadModel` [#1441](https://github.com/ie3-institute/simona/issues/1441)
 - Fixed compiler warnings related to import and scala3 syntax [#1383](https://github.com/ie3-institute/simona/issues/1383)
+- Cleaned up dependencies [#1539](https://github.com/ie3-institute/simona/issues/1539)
 
 ### Removed
 - Removed unused classes and methods related to pekko classic actors [#1389](https://github.com/ie3-institute/simona/issues/1389)

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,9 @@ dependencies {
   testImplementation "com.dimafeng:testcontainers-scala-postgresql_${scalaVersion}:${testContainerVersion}"
   testImplementation "com.dimafeng:testcontainers-scala-kafka_${scalaVersion}:${testContainerVersion}"
 
+  // test-related csv
+  testImplementation 'org.apache.commons:commons-csv:1.14.1'
+
   /* --- Scala libs --- */
   /* CORE Scala */
   implementation "org.scala-lang:scala3-library_3:${scalaBinaryVersion}"
@@ -143,7 +146,6 @@ dependencies {
   implementation ("org.locationtech.jts:jts-core:${jtsVersion}") {
     exclude group: 'junit', module: 'junit'
   }
-  implementation "org.locationtech.jts.io:jts-io-common:${jtsVersion}"
 
   /* Scala compiler plugin for static code analysis */
   implementation "com.sksamuel.scapegoat:scalac-scapegoat-plugin_${scalaBinaryVersion}:${scapegoatVersion}"
@@ -154,12 +156,10 @@ dependencies {
   implementation "io.confluent:kafka-streams-avro-serde:${confluentKafkaVersion}"
   implementation "com.sksamuel.avro4s:avro4s-core_${scalaVersion}:5.0.14"
 
-  implementation 'org.apache.commons:commons-math3:3.6.1' // apache commons math3
-  implementation 'org.apache.poi:poi-ooxml:5.4.1' // used for FilenameUtils
+  implementation 'commons-io:commons-io:2.20.0' // used for FilenameUtils
   implementation 'javax.measure:unit-api:2.2'
   implementation 'tech.units:indriya:2.2.3' // quantities
   implementation "org.typelevel:squants_${scalaVersion}:1.8.3"
-  implementation 'org.apache.commons:commons-csv:1.14.1'
   implementation "org.scalanlp:breeze_${scalaVersion}:2.1.0" // scientific calculations (http://www.scalanlp.org/)
   implementation 'org.jgrapht:jgrapht-core:1.5.2'
 


### PR DESCRIPTION
Resolves #1539

- `org.apache.commons:commons-csv`: Only used in tests -> `testImplementation`, results in smaller jar
- `org.locationtech.jts.io:jts-io-common`: Not used at all
- `org.apache.commons:commons-math3`: Not used at all
- `org.apache.poi:poi-ooxml:`: We only use it for `FileNameUtils`, thus `commons-io:commons-io` suffices

With a little bit of grit, probably more could be done:
- `jgrapht`: Only used for checking connectivity in `GridModel`, which is already implemented in PSDM  (`ConnectorValidationUtils#checkConnectivity`)
- `breeze`: Only used in `DbfsAlgorithm`, not sure if really required
- `jts`: Only used for its `Point` class
- `scopt`: We don't do much argument parsing besides `--config` anyways

Also, one could comb through our own dependencies and do the same there