### PR TITLE
Fixing HP model returning current tick as next activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed consideration of `ThermalStorage` maximum thermal power [#1562](https://github.com/ie3-institute/simona/issues/1562)
 - Fixed shadowJar reference.conf not being merged [#1575](https://github.com/ie3-institute/simona/issues/1575)
 - Fixed `CHANGELOG` entry for #1607 [#1609](https://github.com/ie3-institute/simona/issues/1609)
+- Fixed HP model returning current tick as the next activation [#1622](https://github.com/ie3-institute/simona/issues/1622)
 
 ### Removed
 - Removed unused classes and methods related to pekko classic actors [#1389](https://github.com/ie3-institute/simona/issues/1389)

--- a/src/main/scala/edu/ie3/simona/model/thermal/ThermalHouse.scala
+++ b/src/main/scala/edu/ie3/simona/model/thermal/ThermalHouse.scala
@@ -435,11 +435,8 @@ final case class ThermalHouse(
         None
       }
 
-    // If next threshold is negative or zero (e.g. due to overheating beyond target temperature) there should be no next threshold
-    maybeNextThreshold match {
-      case Some(threshold) if threshold.tick <= 0 => None
-      case _                                      => maybeNextThreshold
-    }
+    // If the time to next threshold is negative or zero (e.g. due to overheating beyond target temperature) there should be no next threshold
+    maybeNextThreshold.filter(_.tick > thermalHouseState.tick)
   }
 
   private def nextActivation(

--- a/src/test/scala/edu/ie3/simona/model/thermal/ThermalHouseSpec.scala
+++ b/src/test/scala/edu/ie3/simona/model/thermal/ThermalHouseSpec.scala
@@ -6,9 +6,6 @@
 
 package edu.ie3.simona.model.thermal
 
-import edu.ie3.datamodel.models.input.OperatorInput
-import edu.ie3.datamodel.models.input.thermal.ThermalHouseInput
-import edu.ie3.datamodel.models.{OperationTime, StandardUnits}
 import edu.ie3.simona.model.participant.hp.HpModel.{HpOperatingPoint, HpState}
 import edu.ie3.simona.model.thermal.ThermalGrid.ThermalGridState
 import edu.ie3.simona.model.thermal.ThermalHouse.ThermalHouseThreshold.{
@@ -23,7 +20,7 @@ import edu.ie3.simona.model.thermal.ThermalStorage.ThermalStorageState
 import edu.ie3.simona.test.common.input.HpInputTestData
 import edu.ie3.simona.test.common.{DefaultTestData, UnitSpec}
 import edu.ie3.simona.util.TickUtil.TickLong
-import edu.ie3.util.scala.quantities.DefaultQuantities.zeroKWh
+import edu.ie3.util.scala.quantities.DefaultQuantities.{zeroKW, zeroKWh}
 import edu.ie3.util.scala.quantities.WattsPerKelvin
 import org.scalatest.prop.{TableFor2, TableFor3, TableFor4, TableFor7}
 import squants.energy.*
@@ -31,11 +28,8 @@ import squants.space.Litres
 import squants.thermal.*
 import squants.time.*
 import squants.{Energy, Temperature, Volume}
-import tech.units.indriya.quantity.Quantities.getQuantity
-import tech.units.indriya.unit.Units
 
 import java.time.ZonedDateTime
-import java.util.UUID
 
 class ThermalHouseSpec
     extends UnitSpec
@@ -394,6 +388,16 @@ class ThermalHouseSpec
 
           thresholdOption shouldBe expectedThreshold
       }
+    }
+
+    "return no next tick if house temperature is within tolerance margin" in {
+      val house = thermalHouse(19, 21)
+      val state = ThermalHouseState(900L, Celsius(0), Celsius(19.0001))
+
+      house.determineNextThreshold(
+        state,
+        zeroKW,
+      ) shouldBe None
     }
 
     "calculating thermal energy demand for heating water" should {


### PR DESCRIPTION
Closes #1622

The problem was actually not that complex, but just an oversight within the safeguard that should've prevent this issue. I added a small test.