### PR TITLE
Implementing forecast for `LoadProfileService`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create trait for secondary service registration, to be used by EmAgent as well [#1635](https://github.com/ie3-institute/simona/issues/1635)
 - Provide extra functionality for `EnergyBoundariesFlexOptions` [#1670](https://github.com/ie3-institute/simona/issues/1670)
 - Implemented EnergyPriceService [#1586](https://github.com/ie3-institute/simona/issues/1586)
+- Implemented forecast for `LoadProfileService` [#1704](https://github.com/ie3-institute/simona/issues/1704)
 
 ### Changed
 - Upgraded `scala2` to `scala3` [#53](https://github.com/ie3-institute/simona/issues/53)

--- a/src/main/scala/edu/ie3/simona/service/load/LoadProfileService.scala
+++ b/src/main/scala/edu/ie3/simona/service/load/LoadProfileService.scala
@@ -18,19 +18,26 @@ import edu.ie3.simona.ontology.messages.ServiceMessage.{
   SecondaryServiceRegistrationMessage,
   ServiceRegistrationMessage,
 }
-import edu.ie3.simona.service.Data.SecondaryData.{LoadData, LoadDataFunction}
+import edu.ie3.simona.service.Data.SecondaryData
+import edu.ie3.simona.service.Data.SecondaryData.{
+  LoadData,
+  LoadDataFunction,
+  SecondarySeriesData,
+}
 import edu.ie3.simona.service.ServiceStateData.{
   InitializeServiceStateData,
   ServiceBaseStateData,
 }
-import edu.ie3.simona.service.{DataTimeType, SimonaService}
+import edu.ie3.simona.service.{Data, DataTimeType, SimonaService}
 import edu.ie3.simona.util.SimonaConstants.FIRST_TICK_IN_SIMULATION
 import edu.ie3.simona.util.TickUtil.TickLong
+import edu.ie3.util.scala.collection.immutable.RichMultiMap.*
 import org.apache.pekko.actor.typed.ActorRef
 import org.apache.pekko.actor.typed.scaladsl.ActorContext
 import org.slf4j.Logger
 
 import java.time.ZonedDateTime
+import scala.collection.immutable.SortedMap
 import scala.util.{Failure, Success, Try}
 
 /** Load Profile Service is responsible to register other actors that require
@@ -41,21 +48,31 @@ object LoadProfileService extends SimonaService {
 
   override type S = LoadProfileInitializedStateData
 
+  /** Container storing registered actors for a load profile.
+    *
+    * @param registrantsMap
+    *   A map of data time type to registered actors.
+    */
+  final case class RegistrantsContainer(
+      registrantsMap: Map[DataTimeType, Set[
+        ActorRef[ServiceMessage.Response]
+      ]] = Map.empty
+  )
+
   /** @param loadProfileStore
     *   That stores that contains all load profiles.
-    * @param profileToRefs
-    *   Map: actor ref to [[LoadProfile]].
+    * @param registeredAgents
+    *   Registered agents by [[LoadProfile]].
     * @param profileResolutions
     *   Map: [[LoadProfile]] to resolution.
     * @param profileToNextActivationTick
-    *   Map: [[LoadProfile]] to next activation tick..
+    *   Map: [[LoadProfile]] to next activation tick.
     * @param simulationStartTime
     *   Start of the simulation.
     */
   final case class LoadProfileInitializedStateData(
       loadProfileStore: LoadProfileStore,
-      profileToRefs: Map[LoadProfile, Seq[ActorRef[ServiceMessage.Response]]] =
-        Map.empty,
+      registeredAgents: Map[LoadProfile, RegistrantsContainer] = Map.empty,
       profileResolutions: Map[LoadProfile, Long],
       profileToNextActivationTick: Map[LoadProfile, Long],
       simulationStartTime: ZonedDateTime,
@@ -122,12 +139,9 @@ object LoadProfileService extends SimonaService {
           dataTimeType,
           loadProfile: LoadProfile,
         ) =>
-      if dataTimeType != DataTimeType.Current then
-        ctx.log.warn(
-          s"Data time type $dataTimeType is currently not supported."
-        )
-
-      Success(handleRegistrationRequest(requestingActor, loadProfile))
+      Success(
+        handleRegistrationRequest(requestingActor, loadProfile, dataTimeType)
+      )
     case invalidMessage =>
       Failure(
         InvalidRegistrationRequestException(
@@ -141,29 +155,38 @@ object LoadProfileService extends SimonaService {
     * value provision.
     *
     * @param agentToBeRegistered
-    *   the agent that wants to be registered
+    *   The agent that wants to be registered.
     * @param loadProfile
-    *   of the agent
+    *   The load profile that the agent wants to receive data for.
+    * @param dataTimeType
+    *   The data time type that the agent wants to receive data for.
     * @param serviceStateData
-    *   the current service state data of this service
+    *   The current service state data of this service.
     * @return
-    *   an updated state data of this service that contains registration
-    *   information if the registration has been carried out successfully
+    *   An updated state data of this service that contains registration
+    *   information if the registration has been carried out successfully.
     */
   private def handleRegistrationRequest(
       agentToBeRegistered: ActorRef[ServiceMessage.Response],
       loadProfile: LoadProfile,
+      dataTimeType: DataTimeType,
   )(using
       serviceStateData: LoadProfileInitializedStateData,
       ctx: ActorContext[Message],
   ): LoadProfileInitializedStateData = {
 
-    serviceStateData.profileToRefs.get(loadProfile) match {
-      case None =>
-        /* The load profile itself is not known yet. Try to figure out, which load profile is relevant */
-
-        if serviceStateData.loadProfileStore.contains(loadProfile) then {
-          // we can provide data for the agent
+    getRegistrantsContainer(loadProfile) match {
+      case Success(registrants) =>
+        if registrants.registrantsMap.contains(
+            dataTimeType,
+            agentToBeRegistered,
+          )
+        then
+          ctx.log.warn(
+            "Sending actor {} is already registered",
+            agentToBeRegistered,
+          )
+        else
           agentToBeRegistered ! RegistrationSuccessfulMessage(
             ctx.self,
             FIRST_TICK_IN_SIMULATION,
@@ -172,45 +195,45 @@ object LoadProfileService extends SimonaService {
             ),
           )
 
-          serviceStateData.copy(profileToRefs =
-            serviceStateData.profileToRefs + (loadProfile -> Seq(
-              agentToBeRegistered
-            ))
-          )
-        } else {
-          // we cannot provide data for the agent
-          ctx.log.error(
-            s"Unable to obtain necessary information to register for load profile '${loadProfile.getKey}'."
+        val updatedRegistrants =
+          registrants.copy(registrantsMap =
+            registrants.registrantsMap.added(dataTimeType, agentToBeRegistered)
           )
 
-          agentToBeRegistered ! RegistrationFailedMessage(ctx.self)
-          serviceStateData
-        }
-
-      case Some(actorRefs) if !actorRefs.contains(agentToBeRegistered) =>
-        // load profile is already known (= we have data for it), but this actor is not registered yet
-        agentToBeRegistered ! RegistrationSuccessfulMessage(
-          ctx.self,
-          FIRST_TICK_IN_SIMULATION,
-          serviceStateData.loadProfileStore.getProfileLoadFactoryData(
-            loadProfile
-          ),
+        serviceStateData.copy(registeredAgents =
+          serviceStateData.registeredAgents
+            .updated(loadProfile, updatedRegistrants)
         )
 
-        serviceStateData.copy(
-          profileToRefs =
-            serviceStateData.profileToRefs + (loadProfile -> (actorRefs :+ agentToBeRegistered))
+      case Failure(exception) =>
+        ctx.log.error(
+          s"Unable to register for load profile '${loadProfile.getKey}'.",
+          exception,
         )
 
-      case _ =>
-        // actor is already registered, do nothing
-        ctx.log.warn(
-          "Sending actor {} is already registered",
-          agentToBeRegistered,
-        )
+        agentToBeRegistered ! RegistrationFailedMessage(ctx.self)
         serviceStateData
     }
+
   }
+
+  /** Retrieves or creates the [[RegistrantsContainer]] for given load profile.
+    */
+  private def getRegistrantsContainer(loadProfile: LoadProfile)(using
+      serviceStateData: LoadProfileInitializedStateData
+  ): Try[RegistrantsContainer] =
+    serviceStateData.registeredAgents.get(loadProfile) match {
+      case None =>
+        if serviceStateData.loadProfileStore.contains(loadProfile) then
+          Success(RegistrantsContainer())
+        else
+          Failure(
+            InvalidRegistrationRequestException(
+              s"Cannot register an agent for load profile $loadProfile, which is not available!"
+            )
+          )
+      case Some(container) => Success(container)
+    }
 
   override protected def announceInformation(tick: Long)(using
       serviceStateData: LoadProfileInitializedStateData,
@@ -220,7 +243,7 @@ object LoadProfileService extends SimonaService {
     val time = tick.toDateTime
 
     val loadProfileStore = serviceStateData.loadProfileStore
-    val profileToRefs = serviceStateData.profileToRefs
+    val registeredAgents = serviceStateData.registeredAgents
 
     /* Calculate the next activation ticks */
     val resolutions = serviceStateData.profileResolutions
@@ -234,37 +257,69 @@ object LoadProfileService extends SimonaService {
       }
 
     activations.foreach { case (loadProfile, nextTick) =>
-      profileToRefs.get(loadProfile).foreach { actorRefs =>
-        loadProfile match {
-          case LoadProfile.RandomLoadProfile.RANDOM_LOAD_PROFILE =>
-            val loadFunction = loadProfileStore.randomEntrySupplier(time)
+      registeredAgents.get(loadProfile).foreach { registrantsContainer =>
+        def dataRetrievalFunc(time: ZonedDateTime): Option[SecondaryData] = {
+          loadProfile match {
+            case LoadProfile.RandomLoadProfile.RANDOM_LOAD_PROFILE =>
+              Some(LoadDataFunction(loadProfileStore.randomEntrySupplier(time)))
+            case _ =>
+              loadProfileStore.entry(time, loadProfile).map(LoadData.apply)
+          }
+        }
 
-            /* Providing random load value function to the requester */
-            actorRefs.foreach(recipient =>
-              recipient ! DataProvision(
-                tick,
-                ctx.self,
-                LoadDataFunction(loadFunction),
-                Some(nextTick),
-              )
-            )
+        registrantsContainer.registrantsMap.foreach {
+          case (dataTimeType, actors) =>
+            val maybeData = dataTimeType match {
+              case DataTimeType.Current =>
+                dataRetrievalFunc(time)
 
-          case _ =>
-            loadProfileStore.entry(time, loadProfile) match {
-              case Some(averagePower) =>
+              case DataTimeType
+                    .CurrentAndForecast(forecastLength, forecastResTime) =>
+                val profileRes = resolutions(loadProfile)
+                val forecastRes = forecastResTime.toSeconds.toLong
+                val endTick = tick + forecastLength.toSeconds.toLong
+
+                // if forecast resolution is a multiple of profile resolution,
+                // we can use forecast resolution instead
+                val adaptedRes =
+                  if forecastRes % profileRes == 0 then forecastRes
+                  else profileRes
+
+                // profile time series is forwarded as forecast without adding noise
+                val series =
+                  Range.Long
+                    .inclusive(tick, endTick, adaptedRes)
+                    .flatMap { tickIt =>
+                      val timeIt = tickIt.toDateTime
+                      val data = dataRetrievalFunc(timeIt)
+
+                      data.map(tickIt -> _)
+                    }
+                    .to(SortedMap)
+
+                Some(
+                  SecondarySeriesData(
+                    reduceTimeSeriesResolution(series, forecastResTime)
+                  )
+                )
+
+            }
+
+            maybeData match {
+              case Some(data) =>
                 /* Sending the found value to the requester */
-                actorRefs.foreach(recipient =>
-                  recipient ! DataProvision(
+                actors.foreach(
+                  _ ! DataProvision(
                     tick,
                     ctx.self,
-                    LoadData(averagePower),
+                    data,
                     Some(nextTick),
                   )
                 )
               case None =>
                 /* There is no data available in the source. */
                 ctx.log.warn(
-                  s"No power value found for load profile {} for time: {}",
+                  s"No data found for load profile {} for time: {}",
                   loadProfile,
                   time,
                 )

--- a/src/main/scala/edu/ie3/simona/service/load/LoadProfileStore.scala
+++ b/src/main/scala/edu/ie3/simona/service/load/LoadProfileStore.scala
@@ -14,10 +14,7 @@ import edu.ie3.simona.exceptions.CriticalFailureException
 import edu.ie3.simona.model.participant.load.ProfileLoadModel.ProfileLoadFactoryData
 import edu.ie3.simona.util.SimonaConstants.FIRST_TICK_IN_SIMULATION
 import edu.ie3.simona.util.TickUtil.RichZonedDateTime
-import edu.ie3.util.scala.quantities.QuantityConversionUtils.{
-  toApparent,
-  toSquants,
-}
+import edu.ie3.util.scala.quantities.QuantityConversionUtils.toSquants
 import tech.units.indriya.ComparableQuantity
 
 import java.time.ZonedDateTime

--- a/src/main/scala/edu/ie3/simona/service/weather/WeatherService.scala
+++ b/src/main/scala/edu/ie3/simona/service/weather/WeatherService.scala
@@ -21,6 +21,7 @@ import edu.ie3.simona.service.weather.WeatherSource.WeightedCoordinates
 import edu.ie3.simona.util.TickUtil.RichZonedDateTime
 import edu.ie3.simona.util.{Coordinate, SimonaConstants}
 import edu.ie3.util.scala.collection.immutable.ActivationTickQueue
+import edu.ie3.util.scala.collection.immutable.RichMultiMap.*
 import org.apache.pekko.actor.typed.ActorRef
 import org.apache.pekko.actor.typed.scaladsl.ActorContext
 import org.slf4j.Logger
@@ -49,15 +50,13 @@ object WeatherService extends SimonaService {
 
   /** Container storing registered actors for a coordinate.
     *
-    * @param registeredActors
-    *   A map of weather data type to registered actors.
+    * @param registrantsMap
+    *   A map of data time type to registered actors.
     * @param coordinateWeights
     *   Weights mapping surrounding coordinates onto the registered coordinate.
     */
-  final case class CoordinateData(
-      registeredActors: Map[DataTimeType, Set[
-        ActorRef[ServiceMessage.Response]
-      ]],
+  final case class RegistrantsContainer(
+      registrantsMap: Map[DataTimeType, Set[ActorRef[ServiceMessage.Response]]],
       coordinateWeights: WeightedCoordinates,
   )
 
@@ -65,7 +64,7 @@ object WeatherService extends SimonaService {
     *
     * @param weatherSource
     *   The weather source to retrieve information from.
-    * @param coordinateData
+    * @param registeredAgents
     *   A map of the requested coords to their receiving actor references.
     * @param activationTicks
     *   A queue of future ticks that the service will be activated at.
@@ -76,7 +75,7 @@ object WeatherService extends SimonaService {
     */
   final case class WeatherBaseStateData(
       weatherSource: WeatherSource,
-      coordinateData: Map[Coordinate, CoordinateData] = Map.empty,
+      registeredAgents: Map[Coordinate, RegistrantsContainer] = Map.empty,
       activationTicks: ActivationTickQueue,
       startDateTime: ZonedDateTime,
       amountOfInterpolationCoords: Int = 4,
@@ -171,7 +170,7 @@ object WeatherService extends SimonaService {
     * @param coordinate
     *   The coordinate of the agent to be registered.
     * @param dataTimeType
-    *   The weather data type that the agent wants to receive.
+    *   The data time type that the agent wants to receive data for.
     * @param serviceStateData
     *   The current service state data of this service.
     * @param ctx
@@ -195,64 +194,74 @@ object WeatherService extends SimonaService {
       coordinate.longitude,
     )
 
-    // collate the provided coordinates into a single entity
-    val registrationResponse = serviceStateData.activationTicks.nextTick
-      .map(RegistrationSuccessfulMessage(ctx.self, _))
-      .getOrElse(RegistrationFailedMessage(ctx.self))
-
-    serviceStateData.coordinateData.get(coordinate) match {
-      case None =>
-        /* The coordinate itself is not known yet. Try to figure out, which weather coordinates are relevant */
-        serviceStateData.weatherSource.getWeightedCoordinates(
-          coordinate,
-          serviceStateData.amountOfInterpolationCoords,
-        ) match {
-          case Success(weightedCoordinates) =>
-            agentToBeRegistered ! registrationResponse
-
-            val coordinateData = CoordinateData(
-              registeredActors = Map(dataTimeType -> Set(agentToBeRegistered)),
-              coordinateWeights = weightedCoordinates,
-            )
-
-            /* Enhance the mapping from agent coordinate to requesting actor's ActorRef as well as the necessary
-             * weather coordinates for later averaging. */
-            serviceStateData.copy(
-              coordinateData =
-                serviceStateData.coordinateData + (coordinate -> coordinateData)
-            )
-          case Failure(exception) =>
-            ctx.log.error(
-              s"Unable to obtain necessary information to register for coordinate $coordinate.",
-              exception,
-            )
-            agentToBeRegistered ! RegistrationFailedMessage(ctx.self)
-            serviceStateData
-        }
-
-      case Some(coordinateData) =>
-        val registeredActors =
-          coordinateData.registeredActors.getOrElse(dataTimeType, Set.empty)
-
-        if registeredActors.contains(agentToBeRegistered) then
+    getRegistrantsContainer(coordinate) match {
+      case Success(registrants) =>
+        if registrants.registrantsMap.contains(
+            dataTimeType,
+            agentToBeRegistered,
+          )
+        then
           ctx.log.warn(
             "Sending actor {} is already registered",
             agentToBeRegistered,
           )
-        else agentToBeRegistered ! registrationResponse
+        else {
+          val registrationResponse = serviceStateData.activationTicks.nextTick
+            .map(RegistrationSuccessfulMessage(ctx.self, _))
+            .getOrElse(RegistrationFailedMessage(ctx.self))
 
-        val adaptedCoordinateData = coordinateData.copy(registeredActors =
-          coordinateData.registeredActors +
-            (dataTimeType -> registeredActors.incl(agentToBeRegistered))
+          agentToBeRegistered ! registrationResponse
+        }
+
+        val updatedRegistrants =
+          registrants.copy(registrantsMap =
+            registrants.registrantsMap.added(dataTimeType, agentToBeRegistered)
+          )
+
+        serviceStateData.copy(registeredAgents =
+          serviceStateData.registeredAgents
+            .updated(coordinate, updatedRegistrants)
         )
-
-        serviceStateData.copy(
-          coordinateData =
-            serviceStateData.coordinateData + (coordinate -> adaptedCoordinateData)
+      case Failure(exception) =>
+        ctx.log.error(
+          s"Unable to register for coordinate $coordinate.",
+          exception,
         )
-
+        agentToBeRegistered ! RegistrationFailedMessage(ctx.self)
+        serviceStateData
     }
   }
+
+  /** Retrieves or creates the [[RegistrantsContainer]] for given coordinate.
+    */
+  private def getRegistrantsContainer(coordinate: Coordinate)(using
+      serviceStateData: WeatherBaseStateData
+  ): Try[RegistrantsContainer] =
+    serviceStateData.registeredAgents.get(coordinate) match {
+      case None =>
+        serviceStateData.weatherSource
+          .getWeightedCoordinates(
+            coordinate,
+            serviceStateData.amountOfInterpolationCoords,
+          )
+          .transform(
+            weightedCoordinates =>
+              Success(
+                RegistrantsContainer(
+                  registrantsMap = Map.empty,
+                  coordinateWeights = weightedCoordinates,
+                )
+              ),
+            exception =>
+              Failure(
+                InvalidRegistrationRequestException(
+                  s"Unable to obtain necessary information to register for coordinate $coordinate.",
+                  exception,
+                )
+              ),
+          )
+      case Some(container) => Success(container)
+    }
 
   override protected def announceInformation(tick: Long)(using
       serviceStateData: WeatherBaseStateData,
@@ -270,10 +279,10 @@ object WeatherService extends SimonaService {
     // get the weather and send it to the subscribed agents
     // no sanity check needed here as we can assume that we always have weather available
     // when we announce it. Otherwise, the registration would have failed already!
-    updatedStateData.coordinateData.foreach { case (_, coordinateData) =>
-      val coordinateWeights = coordinateData.coordinateWeights
+    updatedStateData.registeredAgents.foreach { case (_, container) =>
+      val coordinateWeights = container.coordinateWeights
 
-      coordinateData.registeredActors.foreach { case (dataTimeType, actors) =>
+      container.registrantsMap.foreach { case (dataTimeType, actors) =>
         val weatherData = dataTimeType match {
           case DataTimeType.Current =>
             updatedStateData.weatherSource.getWeather(tick, coordinateWeights)

--- a/src/main/scala/edu/ie3/util/scala/collection/immutable/RichMultiMap.scala
+++ b/src/main/scala/edu/ie3/util/scala/collection/immutable/RichMultiMap.scala
@@ -1,0 +1,41 @@
+/*
+ * © 2026. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
+
+package edu.ie3.util.scala.collection.immutable
+
+/** Extension for a `Map[K, Set[V]]`, i.e. a map with sets as values.
+  */
+object RichMultiMap {
+
+  extension [K, V](map: Map[K, Set[V]]) {
+
+    /** Tests if given value is contained in the set for given key.
+      */
+    def contains(key: K, value: V): Boolean =
+      map.get(key).exists(_.contains(value))
+
+    /** Adds given value to the set of given key. Creates a new set, if such
+      * does not exist for the key.
+      */
+    def added(key: K, value: V): Map[K, Set[V]] =
+      map.updated(key, getOrEmptySet(key).incl(value))
+
+    /** Removes given value from the set of given key. Removes the updated set,
+      * if it is empty after removal.
+      */
+    def removed(key: K, value: V): Map[K, Set[V]] = {
+      val updatedSet = getOrEmptySet(key).excl(value)
+
+      if updatedSet.isEmpty then map.removed(key)
+      else map.updated(key, updatedSet)
+    }
+
+    private def getOrEmptySet(key: K): Set[V] =
+      map.getOrElse(key, Set.empty)
+
+  }
+
+}

--- a/src/test/scala/edu/ie3/simona/service/load/LoadProfileServiceSpec.scala
+++ b/src/test/scala/edu/ie3/simona/service/load/LoadProfileServiceSpec.scala
@@ -18,7 +18,7 @@ import edu.ie3.simona.ontology.messages.SchedulerMessage.{
 import edu.ie3.simona.ontology.messages.ServiceMessage.*
 import edu.ie3.simona.ontology.messages.{Activation, SchedulerMessage}
 import edu.ie3.simona.scheduler.ScheduleLock
-import edu.ie3.simona.service.Data.SecondaryData.LoadData
+import edu.ie3.simona.service.Data.SecondaryData.{LoadData, SecondarySeriesData}
 import edu.ie3.simona.service.DataTimeType
 import edu.ie3.simona.service.load.LoadProfileService.InitLoadProfileServiceStateData
 import edu.ie3.simona.test.common.{ConfigTestData, TestSpawnerTyped}
@@ -31,6 +31,7 @@ import org.apache.pekko.actor.testkit.typed.scaladsl.{
 import org.scalatest.PrivateMethodTester
 import org.scalatest.wordspec.AnyWordSpecLike
 import squants.energy.{KilowattHours, Kilowatts, Watts}
+import squants.time.Hours
 
 import scala.language.implicitConversions
 
@@ -44,12 +45,14 @@ class LoadProfileServiceSpec
 
   private val sourceDefinition: Datasource = Datasource()
 
-  private val invalidLoadProfile = new LoadProfile {
+  private val invalidLoadProfile: LoadProfile = new LoadProfile {
     override def getKey: String = "invalid"
   }
 
   private val scheduler = TestProbe[SchedulerMessage]("scheduler")
-  private val agent = TestProbe[ParticipantAgent.Message]("agent")
+
+  private val agent1 = TestProbe[ParticipantAgent.Message]("agent")
+  private val agent2 = TestProbe[ParticipantAgent.Message]("agent2")
 
   // build the load profile service
   private val loadProfileService = testKit.spawn(
@@ -57,7 +60,7 @@ class LoadProfileServiceSpec
   )
 
   "A load profile service" should {
-    "receive correct completion message after initialisation" in {
+    "send correct completion message after initialisation" in {
       val key =
         ScheduleLock.singleKey(TSpawner, scheduler.ref, INIT_SIM_TICK)
       scheduler
@@ -83,23 +86,23 @@ class LoadProfileServiceSpec
 
     "announce failed load profile registration on invalid load profile" in {
       loadProfileService ! SecondaryServiceRegistrationMessage(
-        agent.ref,
+        agent1.ref,
         DataTimeType.Current,
         invalidLoadProfile,
       )
 
-      agent.expectMessage(RegistrationFailedMessage(loadProfileService))
+      agent1.expectMessage(RegistrationFailedMessage(loadProfileService))
     }
 
     "announce, that a load profile is registered" in {
       /* The successful registration stems from the test above */
       loadProfileService ! SecondaryServiceRegistrationMessage(
-        agent.ref,
+        agent1.ref,
         DataTimeType.Current,
         BdewStandardLoadProfile.G0,
       )
 
-      agent.expectMessage(
+      agent1.expectMessage(
         RegistrationSuccessfulMessage(
           loadProfileService,
           0L,
@@ -113,15 +116,41 @@ class LoadProfileServiceSpec
       )
     }
 
-    "recognize, that a valid coordinate yet is registered" in {
-      /* The successful registration stems from the test above */
+    "announce, that a valid coordinate is registered for forecast data" in {
       loadProfileService ! SecondaryServiceRegistrationMessage(
-        agent.ref,
+        agent2.ref,
+        DataTimeType.CurrentAndForecast(
+          forecastLength = Hours(6),
+          forecastResolution = Hours(1),
+        ),
+        BdewStandardLoadProfile.H0,
+      )
+
+      agent2.expectMessage(
+        RegistrationSuccessfulMessage(
+          loadProfileService,
+          0L,
+          Some(
+            ProfileLoadFactoryData(
+              Some(Watts(268.6)),
+              Some(KilowattHours(1000)),
+            )
+          ),
+        )
+      )
+
+      agent1.expectNoMessage()
+    }
+
+    "recognize that agent is already registered" in {
+      loadProfileService ! SecondaryServiceRegistrationMessage(
+        agent1.ref,
         DataTimeType.Current,
         BdewStandardLoadProfile.G0,
       )
 
-      agent.expectNoMessage()
+      agent1.expectNoMessage()
+      agent2.expectNoMessage()
     }
 
     "send out correct load profile information upon activity start trigger and request the triggering for the next tick" in {
@@ -131,7 +160,7 @@ class LoadProfileServiceSpec
       val activationMsg = scheduler.expectMessageType[Completion]
       activationMsg.newTick shouldBe Some(900)
 
-      agent.expectMessage(
+      agent1.expectMessage(
         DataProvision(
           0,
           loadProfileService,
@@ -139,6 +168,19 @@ class LoadProfileServiceSpec
           Some(900L),
         )
       )
+
+      agent2.expectMessageType[DataProvision] match {
+        case DataProvision(tick, serviceRef, data, nextTick) =>
+          tick shouldBe 0L
+          serviceRef shouldBe loadProfileService
+          data match {
+            case SecondarySeriesData(series) =>
+              series.size shouldBe 7
+            case unexpected =>
+              fail(s"Received unexpected data $unexpected")
+          }
+          nextTick shouldBe Some(900L)
+      }
 
     }
 
@@ -149,7 +191,7 @@ class LoadProfileServiceSpec
       val activationMsg = scheduler.expectMessageType[Completion]
       activationMsg.newTick shouldBe Some(1800)
 
-      agent.expectMessage(
+      agent1.expectMessage(
         DataProvision(
           900,
           loadProfileService,

--- a/src/test/scala/edu/ie3/util/scala/collection/immutable/RichMultiMapSpec.scala
+++ b/src/test/scala/edu/ie3/util/scala/collection/immutable/RichMultiMapSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * © 2026. TU Dortmund University,
+ * Institute of Energy Systems, Energy Efficiency and Energy Economics,
+ * Research group Distribution grid planning and operation
+ */
+
+package edu.ie3.util.scala.collection.immutable
+
+import edu.ie3.simona.test.common.UnitSpec
+import edu.ie3.util.scala.collection.immutable.RichMultiMap.*
+
+class RichMultiMapSpec extends UnitSpec {
+
+  private val testSet: Map[Int, Set[String]] =
+    Map(1 -> Set("a", "b"), 2 -> Set("c"))
+
+  "Functionality for a multi map" should {
+
+    "test for containment correctly" in {
+
+      testSet.contains(1, "a") shouldBe true
+      testSet.contains(1, "c") shouldBe false
+      testSet.contains(3, "a") shouldBe false
+
+    }
+
+    "add items correctly" in {
+
+      testSet.added(1, "c") shouldBe testSet.updated(1, Set("a", "b", "c"))
+      testSet.added(3, "d") shouldBe testSet.updated(3, Set("d"))
+
+    }
+
+    "remove items correctly" in {
+
+      testSet.removed(1, "a") shouldBe testSet.updated(1, Set("b"))
+      testSet.removed(2, "c") shouldBe testSet.removed(2)
+      testSet.removed(3, "a") shouldBe testSet
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Closes #1704 

- Also introducing `RichMultiMap` that simplifies dealing with `Map[K, Set[V]]`.
- Furthermore I tried to abstract functionality from weather and load profile service, but I think further refactoring is not worth it given the inherent differences between the implementations.