### PR TITLE
Fixing PV log spamming in the night

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `CHANGELOG` entry for #1607 [#1609](https://github.com/ie3-institute/simona/issues/1609)
 - Fixed HP model returning current tick as the next activation [#1622](https://github.com/ie3-institute/simona/issues/1622)
 - Disallowed EMs as inferiors of `PrioritizedFlexStrat` [#1712](https://github.com/ie3-institute/simona/issues/1712)
+- Fixed log spamming during night time due to no solar irradiance [#984](https://github.com/ie3-institute/simona/issues/984)
 
 ### Removed
 - Removed unused classes and methods related to pekko classic actors [#1389](https://github.com/ie3-institute/simona/issues/1389)

--- a/src/main/scala/edu/ie3/simona/service/weather/WeatherSource.scala
+++ b/src/main/scala/edu/ie3/simona/service/weather/WeatherSource.scala
@@ -367,39 +367,34 @@ object WeatherSource {
     }
   }
 
-  /** Represents an empty weather data object.
+  /** Converts given [[WeatherValue]] to [[WeatherData]]. If a specific value
+    * within [[WeatherValue]] is not present (null), it is replaced by
+    * Double.Nan in [[WeatherData]].
     *
-    * For temperature to represent an "empty" quantity, we need to explicitly
-    * set temperature to absolute zero, so 0 K. When temperature measures the
-    * movement of atoms, absolute zero means no movement, which represents the
-    * "empty" concept best.
+    * @param weatherValue
+    *   The [[WeatherValue]] to convert.
+    * @return
+    *   A corresponding [[WeatherData]] object.
     */
-  val EMPTY_WEATHER_DATA: WeatherData = WeatherData(
-    WattsPerSquareMeter(0.0),
-    WattsPerSquareMeter(0.0),
-    Kelvin(0d),
-    MetersPerSecond(0d),
-  )
-
   def toWeatherData(
       weatherValue: WeatherValue
   ): WeatherData = {
     WeatherData(
       weatherValue.getSolarIrradiance.getDiffuseIrradiance.toScala match {
         case Some(irradiance) => irradiance.toSquants
-        case None             => EMPTY_WEATHER_DATA.diffIrr
+        case None             => WattsPerSquareMeter(Double.NaN)
       },
       weatherValue.getSolarIrradiance.getDirectIrradiance.toScala match {
         case Some(irradiance) => irradiance.toSquants
-        case None             => EMPTY_WEATHER_DATA.dirIrr
+        case None             => WattsPerSquareMeter(Double.NaN)
       },
       weatherValue.getTemperature.getTemperature.toScala match {
         case Some(temperature) => temperature.toSquants
-        case None              => EMPTY_WEATHER_DATA.temp
+        case None              => Kelvin(Double.NaN)
       },
       weatherValue.getWind.getVelocity.toScala match {
         case Some(windVel) => windVel.toSquants
-        case None          => EMPTY_WEATHER_DATA.windVel
+        case None          => MetersPerSecond(Double.NaN)
       },
     )
 

--- a/src/main/scala/edu/ie3/simona/service/weather/WeatherSourceWrapper.scala
+++ b/src/main/scala/edu/ie3/simona/service/weather/WeatherSourceWrapper.scala
@@ -25,26 +25,30 @@ import edu.ie3.datamodel.io.source.{
   IdCoordinateSource,
   WeatherSource as PsdmWeatherSource,
 }
-import edu.ie3.simona.config.InputConfig
 import edu.ie3.simona.config.ConfigParams.{
   BaseCsvParams,
   BaseInfluxDb1xParams,
   CouchbaseParams,
   SqlParams,
 }
+import edu.ie3.simona.config.InputConfig
 import edu.ie3.simona.exceptions.InitializationException
 import edu.ie3.simona.service.Data.SecondaryData.WeatherData
+import edu.ie3.simona.service.weather.WeatherSource as SimonaWeatherSource
 import edu.ie3.simona.service.weather.WeatherSource.{
-  EMPTY_WEATHER_DATA,
   WeatherScheme,
   toWeatherData,
 }
-import edu.ie3.simona.service.weather.WeatherSourceWrapper.WeightSum
-import edu.ie3.simona.service.weather.WeatherSource as SimonaWeatherSource
+import edu.ie3.simona.service.weather.WeatherSourceWrapper.{
+  WeightSum,
+  ZERO_WEATHER_DATA,
+}
 import edu.ie3.simona.util.TickUtil.{RichZonedDateTime, TickLong}
 import edu.ie3.util.DoubleUtils.!~=
 import edu.ie3.util.interval.ClosedInterval
+import edu.ie3.util.scala.quantities.WattsPerSquareMeter
 import org.locationtech.jts.geom.Point
+import squants.motion.MetersPerSecond
 import squants.thermal.Kelvin
 import tech.units.indriya.ComparableQuantity
 
@@ -125,51 +129,54 @@ private[weather] final case class WeatherSourceWrapper private (
   private def spatialDataInterpolation(
       weatherData: Iterable[(Point, WeatherData, Double)]
   ): WeatherData =
-    weatherData.foldLeft((EMPTY_WEATHER_DATA, WeightSum.EMPTY_WEIGHT_SUM)) {
+    weatherData.foldLeft((ZERO_WEATHER_DATA, WeightSum.ZERO_WEIGHT_SUM)) {
       case ((averagedWeather, weightSum), (point, weather, weight)) =>
         /* Calculate the contribution of a single coordinate value to the
-         * averaged weather information. If we got an empty quantity (which can
-         * be the case, as this particular value might be missing in the
-         * weather data), we do let it out and also return the "effective"
-         * weight of 0d.
+         * averaged weather information.
+         *
+         * If we got an empty quantity (Double.Nan, which can be the case,
+         * as this particular value might be missing in the weather data),
+         * we do let it out and also return the "effective"  weight of 0d.
+         *
+         * Careful: Use Double.isNaN because Double.NaN != Double.NaN
          */
 
         /* Determine actual weights and contributions */
-        val (diffIrradiance, diffIrrWeight) = weather.diffIrr match {
-          case EMPTY_WEATHER_DATA.diffIrr =>
+        val (diffIrradiance, diffIrrWeight) =
+          if weather.diffIrr.value.isNaN then {
             // Some data sets do not provide diffuse irradiance, so we do not
             // warn here
-            logger.debug("Diffuse solar irradiance not available at $point.")
+            logger.debug(s"Diffuse solar irradiance not available at $point.")
             (averagedWeather.diffIrr, 0d)
-          case nonEmptyDiffIrr =>
-            (averagedWeather.diffIrr + nonEmptyDiffIrr * weight, weight)
-        }
+          } else {
+            (averagedWeather.diffIrr + weather.diffIrr * weight, weight)
+          }
 
-        val (dirIrradiance, dirIrrWeight) = weather.dirIrr match {
-          case EMPTY_WEATHER_DATA.`dirIrr` =>
+        val (dirIrradiance, dirIrrWeight) =
+          if weather.dirIrr.value.isNaN then {
             logger.warn(s"Direct solar irradiance not available at $point.")
             (averagedWeather.dirIrr, 0d)
-          case nonEmptyDirIrr =>
-            (averagedWeather.dirIrr + nonEmptyDirIrr * weight, weight)
-        }
+          } else {
+            (averagedWeather.dirIrr + weather.dirIrr * weight, weight)
+          }
 
-        val (temperature, tempWeight) = weather.temp match {
-          case EMPTY_WEATHER_DATA.temp =>
+        val (temperature, tempWeight) =
+          if weather.temp.value.isNaN then {
             logger.warn(s"Temperature not available at $point.")
             (averagedWeather.temp, 0d)
-          case nonEmptyTemp =>
+          } else {
             // Important: squants temperature addition is bugged.
             // Conversion to Kelvin necessary.
-            (averagedWeather.temp + nonEmptyTemp.in(Kelvin) * weight, weight)
-        }
+            (averagedWeather.temp + weather.temp.in(Kelvin) * weight, weight)
+          }
 
-        val (windVelocity, windVelWeight) = weather.windVel match {
-          case EMPTY_WEATHER_DATA.windVel =>
+        val (windVelocity, windVelWeight) =
+          if weather.windVel.value.isNaN then {
             logger.warn(s"Wind velocity not available at $point.")
             (averagedWeather.windVel, 0d)
-          case nonEmptyWindVel =>
-            (averagedWeather.windVel + nonEmptyWindVel * weight, weight)
-        }
+          } else {
+            (averagedWeather.windVel + weather.windVel * weight, weight)
+          }
 
         (
           WeatherData(diffIrradiance, dirIrradiance, temperature, windVelocity),
@@ -382,18 +389,33 @@ private[weather] object WeatherSourceWrapper extends LazyLogging {
         implicit val precision: Double = 1e-3
         WeatherData(
           if this.diffIrr !~= 0d then diffIrr.divide(this.diffIrr)
-          else EMPTY_WEATHER_DATA.diffIrr,
+          else ZERO_WEATHER_DATA.diffIrr,
           if this.dirIrr !~= 0d then dirIrr.divide(this.dirIrr)
-          else EMPTY_WEATHER_DATA.dirIrr,
+          else ZERO_WEATHER_DATA.dirIrr,
           if this.temp !~= 0d then temp.divide(this.temp)
-          else EMPTY_WEATHER_DATA.temp,
+          else ZERO_WEATHER_DATA.temp,
           if this.windVel !~= 0d then windVel.divide(this.windVel)
-          else EMPTY_WEATHER_DATA.windVel,
+          else ZERO_WEATHER_DATA.windVel,
         )
     }
   }
+
   object WeightSum {
-    val EMPTY_WEIGHT_SUM: WeightSum = WeightSum(0d, 0d, 0d, 0d)
+    val ZERO_WEIGHT_SUM: WeightSum = WeightSum(0d, 0d, 0d, 0d)
   }
+
+  /** Weather data with all values set to zero.
+    *
+    * For temperature to represent a quantity with zero value, we need to
+    * explicitly set temperature to absolute zero, so 0 K. When temperature
+    * measures the movement of atoms, absolute zero means no movement, which
+    * represents the concept best.
+    */
+  val ZERO_WEATHER_DATA: WeatherData = WeatherData(
+    WattsPerSquareMeter(0d),
+    WattsPerSquareMeter(0d),
+    Kelvin(0d),
+    MetersPerSecond(0d),
+  )
 
 }

--- a/src/test/scala/edu/ie3/simona/service/weather/WeatherSourceWrapperSpec.scala
+++ b/src/test/scala/edu/ie3/simona/service/weather/WeatherSourceWrapperSpec.scala
@@ -18,22 +18,22 @@ import edu.ie3.datamodel.models.timeseries.individual.{
 }
 import edu.ie3.datamodel.models.value.WeatherValue
 import edu.ie3.simona.service.Data.SecondaryData.WeatherData
-import edu.ie3.simona.service.weather.WeatherSource.{
-  EMPTY_WEATHER_DATA,
-  WeightedCoordinates,
-}
+import edu.ie3.simona.service.weather.WeatherSource.WeightedCoordinates
 import edu.ie3.simona.service.weather.WeatherSourceSpec.DummyIdCoordinateSource
-import edu.ie3.simona.service.weather.WeatherSourceWrapper.WeightSum
+import edu.ie3.simona.service.weather.WeatherSourceWrapper.{
+  WeightSum,
+  ZERO_WEATHER_DATA,
+}
 import edu.ie3.simona.service.weather.WeatherSourceWrapperSpec.*
 import edu.ie3.simona.test.common.UnitSpec
 import edu.ie3.util.geo.GeoUtils
 import edu.ie3.util.interval.ClosedInterval
 import edu.ie3.util.scala.quantities.{Irradiance, WattsPerSquareMeter}
 import org.locationtech.jts.geom.Point
-import tech.units.indriya.ComparableQuantity
-import squants.{Temperature, Velocity}
 import squants.motion.MetersPerSecond
 import squants.thermal.{Celsius, Kelvin}
+import squants.{Temperature, Velocity}
+import tech.units.indriya.ComparableQuantity
 import tech.units.indriya.quantity.Quantities
 import tech.units.indriya.unit.Units
 
@@ -236,7 +236,7 @@ class WeatherSourceWrapperSpec extends UnitSpec {
 
       weightSum.scale(weightedWeather) match {
         case WeatherData(_, _, temp, _) =>
-          temp shouldBe EMPTY_WEATHER_DATA.temp
+          temp shouldBe ZERO_WEATHER_DATA.temp
       }
     }
 
@@ -445,7 +445,7 @@ object WeatherSourceWrapperSpec {
     }
 
     val weightedWeather =
-      weatherData.zip(weights).foldLeft(EMPTY_WEATHER_DATA) {
+      weatherData.zip(weights).foldLeft(ZERO_WEATHER_DATA) {
         case (
               currentSum,
               (
@@ -460,7 +460,7 @@ object WeatherSourceWrapperSpec {
             windVel = currentSum.windVel + windVel * wVelWeight,
           )
       }
-    val weightSum = weights.foldLeft(WeightSum.EMPTY_WEIGHT_SUM) {
+    val weightSum = weights.foldLeft(WeightSum.ZERO_WEIGHT_SUM) {
       case (currentSum, currentWeight) =>
         currentSum.add(
           currentWeight._1,


### PR DESCRIPTION
Closes #984

Another try from my side. In this solution, I replaced missing values (`null`) with `Double.Nan`, not `0d`. This way, missing and zero values cannot be confused anymore.
I've also taken the liberty to rename `EMPTY_WEATHER_DATA` to `ZERO_WEATHER_DATA`, which makes it a bit clearer what is meant at first glance.