### PR TITLE
Fix unreliable ThermalGridIT/EmAgentIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `EnergyPriceService` initialization [#1747](https://github.com/ie3-institute/simona/issues/1747)
 - Fixed EVCS `OperationChangeIndiactor` in edge cases [#1762](https://github.com/ie3-institute/simona/issues/1762)
 - Fixed `AbstractEnergyBoundariesFlexModel` next tick determination [#1769](https://github.com/ie3-institute/simona/issues/1769)
+- Fix unreliable ThermalGridIT/EmAgentIT [#1757](https://github.com/ie3-institute/simona/issues/1757)
 
 ### Removed
 - Removed unused classes and methods related to pekko classic actors [#1389](https://github.com/ie3-institute/simona/issues/1389)

--- a/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
@@ -434,7 +434,7 @@ class EmAgentIT
         )
         val hpAgent = spawn(
           ParticipantAgentInit(
-            adaptedWithHeatContainer,
+            withHeatContainerEmIT,
             HpRuntimeConfig(),
             outputConfigOff,
             Right(emAgent),
@@ -458,7 +458,7 @@ class EmAgentIT
         primaryServiceProxy.receiveMessages(3) should contain allOf (
           PrimaryServiceRegistrationMessage(
             hpAgent,
-            adaptedHpInputModel.getUuid,
+            hpInputModelEmIT.getUuid,
           ),
           PrimaryServiceRegistrationMessage(
             loadAgent,
@@ -502,8 +502,8 @@ class EmAgentIT
             DataTimeType.Current,
             WeatherRegistrationData(
               Coordinate(
-                adaptedHpInputModel.getNode.getGeoPosition.getY,
-                adaptedHpInputModel.getNode.getGeoPosition.getX,
+                hpInputModelEmIT.getNode.getGeoPosition.getY,
+                hpInputModelEmIT.getNode.getGeoPosition.getX,
               )
             ),
           )

--- a/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
@@ -283,12 +283,9 @@ class EmAgentIT
           Some(14400),
         )
 
-        // we receive a message, since new data arrived
-        resultServiceProxy.expectMessage(
-          ExpectResult(pvInput.getUuid, 7200, true)
-        )
-
-        resultServiceProxy.receiveMessages(3) should contain allOf (
+        resultServiceProxy.receiveMessages(4) should contain allOf (
+          // we receive a message, since new data arrived
+          ExpectResult(pvInput.getUuid, 7200, true),
           // expect no result, since we are still waiting for a new set point
           NoResult(storageInput.getUuid, 7200),
           // we expect results, since we received new set points

--- a/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
@@ -546,13 +546,13 @@ class EmAgentIT
         // we receive a message, since new data arrived
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 0, true),
-          ExpectResult(hpInputModel.getUuid, 0, true)
+          ExpectResult(hpInputModelEmIT.getUuid, 0, true)
         )
 
         // we receive update messages, since a new set point was provided
         resultServiceProxy.receiveMessages(3) should contain allOf (
           ExpectResult(pvInput.getUuid, 0),
-          ExpectResult(hpInputModel.getUuid, 0),
+          ExpectResult(hpInputModelEmIT.getUuid, 0),
           ExpectResult(loadInput.getUuid, 0)
         )
 
@@ -578,9 +578,9 @@ class EmAgentIT
 
         resultServiceProxy.receiveMessages(2) should contain allOf (
           // we receive a message, since new data arrived
-          ExpectResult(hpInputModel.getUuid, 75, true),
+          ExpectResult(hpInputModelEmIT.getUuid, 75, true),
           // we receive update messages, since a new set point was provided
-          ExpectResult(hpInputModel.getUuid, 75)
+          ExpectResult(hpInputModelEmIT.getUuid, 75)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -605,9 +605,9 @@ class EmAgentIT
 
         resultServiceProxy.receiveMessages(2) should contain allOf (
           // we receive a message, since new data arrived
-          ExpectResult(hpInputModel.getUuid, 3600, true),
+          ExpectResult(hpInputModelEmIT.getUuid, 3600, true),
           // we receive update messages, since a new set point was provided
-          ExpectResult(hpInputModel.getUuid, 3600)
+          ExpectResult(hpInputModelEmIT.getUuid, 3600)
         )
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
           case ParticipantResultEvent(emResult: EmResult) =>
@@ -631,9 +631,9 @@ class EmAgentIT
 
         resultServiceProxy.receiveMessages(2) should contain allOf (
           // we receive a message, since new data arrived
-          ExpectResult(hpInputModel.getUuid, 3675, true),
+          ExpectResult(hpInputModelEmIT.getUuid, 3675, true),
           // we receive update messages, since a new set point was provided
-          ExpectResult(hpInputModel.getUuid, 3675)
+          ExpectResult(hpInputModelEmIT.getUuid, 3675)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -662,9 +662,9 @@ class EmAgentIT
 
         resultServiceProxy.receiveMessages(2) should contain allOf (
           // we receive a message, since new data arrived
-          ExpectResult(hpInputModel.getUuid, 6056, true),
+          ExpectResult(hpInputModelEmIT.getUuid, 6056, true),
           // we receive update messages, since a new set point was provided
-          ExpectResult(hpInputModel.getUuid, 6056)
+          ExpectResult(hpInputModelEmIT.getUuid, 6056)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -703,13 +703,13 @@ class EmAgentIT
         // we receive a message, since new data arrived
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 7200, true),
-          ExpectResult(hpInputModel.getUuid, 7200, true)
+          ExpectResult(hpInputModelEmIT.getUuid, 7200, true)
         )
 
         // we receive update messages, since a new set point was provided
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 7200),
-          ExpectResult(hpInputModel.getUuid, 7200)
+          ExpectResult(hpInputModelEmIT.getUuid, 7200)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -734,9 +734,9 @@ class EmAgentIT
 
         resultServiceProxy.receiveMessages(2) should contain allOf (
           // we receive a message, since new data arrived
-          ExpectResult(hpInputModel.getUuid, 7278, true),
+          ExpectResult(hpInputModelEmIT.getUuid, 7278, true),
           // we receive update messages, since a new set point was provided
-          ExpectResult(hpInputModel.getUuid, 7278)
+          ExpectResult(hpInputModelEmIT.getUuid, 7278)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -761,9 +761,9 @@ class EmAgentIT
 
         resultServiceProxy.receiveMessages(2) should contain allOf (
           // we receive a message, since new data arrived
-          ExpectResult(hpInputModel.getUuid, 7981, true),
+          ExpectResult(hpInputModelEmIT.getUuid, 7981, true),
           // we receive update messages, since a new set point was provided
-          ExpectResult(hpInputModel.getUuid, 7981)
+          ExpectResult(hpInputModelEmIT.getUuid, 7981)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -802,13 +802,13 @@ class EmAgentIT
         // we receive a message, since new data arrived
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 10800, true),
-          ExpectResult(hpInputModel.getUuid, 10800, true)
+          ExpectResult(hpInputModelEmIT.getUuid, 10800, true)
         )
 
         // we receive update messages, since a new set point was provided
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 10800),
-          ExpectResult(hpInputModel.getUuid, 10800)
+          ExpectResult(hpInputModelEmIT.getUuid, 10800)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -833,9 +833,9 @@ class EmAgentIT
 
         resultServiceProxy.receiveMessages(2) should contain allOf (
           // we receive a message, since new data arrived
-          ExpectResult(hpInputModel.getUuid, 10879, true),
+          ExpectResult(hpInputModelEmIT.getUuid, 10879, true),
           // we receive update messages, since a new set point was provided
-          ExpectResult(hpInputModel.getUuid, 10879)
+          ExpectResult(hpInputModelEmIT.getUuid, 10879)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -876,13 +876,13 @@ class EmAgentIT
         // we receive a message, since new data arrived
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 11000, true),
-          ExpectResult(hpInputModel.getUuid, 11000, true)
+          ExpectResult(hpInputModelEmIT.getUuid, 11000, true)
         )
 
         // we receive update messages, since a new set point was provided
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 11000),
-          ExpectResult(hpInputModel.getUuid, 11000)
+          ExpectResult(hpInputModelEmIT.getUuid, 11000)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
@@ -923,13 +923,13 @@ class EmAgentIT
         // we receive a message, since new data arrived
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 11500, true),
-          ExpectResult(hpInputModel.getUuid, 11500, true)
+          ExpectResult(hpInputModelEmIT.getUuid, 11500, true)
         )
 
         // we receive update messages, since a new set point was provided
         resultServiceProxy.receiveMessages(2) should contain allOf (
           ExpectResult(pvInput.getUuid, 11500),
-          ExpectResult(hpInputModel.getUuid, 11500)
+          ExpectResult(hpInputModelEmIT.getUuid, 11500)
         )
 
         resultServiceProxy.expectMessageType[ParticipantResultEvent] match {

--- a/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
@@ -690,14 +690,11 @@ class EmAgentIT
           )
         }
 
-        // we receive a message, since new data arrived
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+        resultServiceProxy.receiveMessages(4) should contain allOf (
+          // we receive a message, since new data arrived
           ExpectResult(pvInput.getUuid, 7200, true),
-          ExpectResult(hpInputModelEmIT.getUuid, 7200, true)
-        )
-
-        // we receive update messages, since a new set point was provided
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+          ExpectResult(hpInputModelEmIT.getUuid, 7200, true),
+          // we receive update messages, since a new set point was provided
           ExpectResult(pvInput.getUuid, 7200),
           ExpectResult(hpInputModelEmIT.getUuid, 7200)
         )
@@ -789,14 +786,11 @@ class EmAgentIT
           )
         }
 
-        // we receive a message, since new data arrived
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+        resultServiceProxy.receiveMessages(4) should contain allOf (
+          // we receive a message, since new data arrived
           ExpectResult(pvInput.getUuid, 10800, true),
-          ExpectResult(hpInputModelEmIT.getUuid, 10800, true)
-        )
-
-        // we receive update messages, since a new set point was provided
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+          ExpectResult(hpInputModelEmIT.getUuid, 10800, true),
+          // we receive update messages, since a new set point was provided
           ExpectResult(pvInput.getUuid, 10800),
           ExpectResult(hpInputModelEmIT.getUuid, 10800)
         )
@@ -863,14 +857,11 @@ class EmAgentIT
           )
         }
 
-        // we receive a message, since new data arrived
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+        resultServiceProxy.receiveMessages(4) should contain allOf (
+          // we receive a message, since new data arrived
           ExpectResult(pvInput.getUuid, 11000, true),
-          ExpectResult(hpInputModelEmIT.getUuid, 11000, true)
-        )
-
-        // we receive update messages, since a new set point was provided
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+          ExpectResult(hpInputModelEmIT.getUuid, 11000, true),
+          // we receive update messages, since a new set point was provided
           ExpectResult(pvInput.getUuid, 11000),
           ExpectResult(hpInputModelEmIT.getUuid, 11000)
         )
@@ -910,14 +901,11 @@ class EmAgentIT
           )
         }
 
-        // we receive a message, since new data arrived
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+        resultServiceProxy.receiveMessages(4) should contain allOf (
+          // we receive a message, since new data arrived
           ExpectResult(pvInput.getUuid, 11500, true),
-          ExpectResult(hpInputModelEmIT.getUuid, 11500, true)
-        )
-
-        // we receive update messages, since a new set point was provided
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+          ExpectResult(hpInputModelEmIT.getUuid, 11500, true),
+          // we receive update messages, since a new set point was provided
           ExpectResult(pvInput.getUuid, 11500),
           ExpectResult(hpInputModelEmIT.getUuid, 11500)
         )

--- a/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
@@ -237,11 +237,10 @@ class EmAgentIT
           Some(7200),
         )
 
-        // we receive a message, since new data arrived
-        resultServiceProxy.expectMessage(ExpectResult(pvInput.getUuid, 0, true))
-
-        // we receive update messages, since new set points were provided
-        resultServiceProxy.receiveMessages(3) should contain allOf (
+        resultServiceProxy.receiveMessages(4) should contain allOf (
+          // we receive a message, since new data arrived
+          ExpectResult(pvInput.getUuid, 0, true),
+          // we receive update messages, since new set points were provided
           ExpectResult(pvInput.getUuid, 0),
           ExpectResult(storageInput.getUuid, 0),
           ExpectResult(loadInput.getUuid, 0)
@@ -312,13 +311,10 @@ class EmAgentIT
          */
         emAgentActivation ! Activation(13246)
 
-        // the result proxy will receive ExpectResult messages
-        resultServiceProxy.expectMessage(
-          ExpectResult(storageInput.getUuid, 13246, true)
-        )
-
-        // we receive an update message, since a new set point were provided
-        resultServiceProxy.expectMessage(
+        resultServiceProxy.receiveMessages(2) should contain allOf (
+          // the result proxy will receive ExpectResult messages
+          ExpectResult(storageInput.getUuid, 13246, true),
+          // we receive an update message, since a new set point were provided
           ExpectResult(storageInput.getUuid, 13246)
         )
 
@@ -540,14 +536,11 @@ class EmAgentIT
           )
         }
 
-        // we receive a message, since new data arrived
-        resultServiceProxy.receiveMessages(2) should contain allOf (
+        resultServiceProxy.receiveMessages(5) should contain allOf (
+          // we receive a message, since new data arrived
           ExpectResult(pvInput.getUuid, 0, true),
-          ExpectResult(hpInputModelEmIT.getUuid, 0, true)
-        )
-
-        // we receive update messages, since a new set point was provided
-        resultServiceProxy.receiveMessages(3) should contain allOf (
+          ExpectResult(hpInputModelEmIT.getUuid, 0, true),
+          // we receive update messages, since a new set point was provided
           ExpectResult(pvInput.getUuid, 0),
           ExpectResult(hpInputModelEmIT.getUuid, 0),
           ExpectResult(loadInput.getUuid, 0)

--- a/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
@@ -1439,7 +1439,7 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      resultServiceProxy.receiveMessages(2) should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 1800, true),
         // expect messages due to new set point

--- a/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
@@ -234,55 +234,46 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.expectMessage(
+      val events0 = resultServiceProxy.receiveMessages(5)
+
+      events0 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 0)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
+      events0.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 0.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 0.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(20.asDegreeCelsius)
+      }
+
+      events0
+        .collect {
+          case ThermalResultEvent(
+                AbstractThermalStorageResult(time, inputModel, qDot, energy)
+              ) =>
+            (inputModel, time, qDot, energy)
         }
         .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 0.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 0.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(20.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 0.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                energy should equalWithTolerance(0.asMegaWattHour)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 0.toDateTime
-                qDot should equalWithTolerance(-0.005405957260274.asMegaWatt)
-                energy should equalWithTolerance(0.000522.asMegaWattHour)
-            }
+          case (uuid, time, qDot, energy)
+              if uuid == typicalHeatStorage.getUuid =>
+            time shouldBe 0.toDateTime
+            qDot should equalWithTolerance(0.011.asMegaWatt)
+            energy should equalWithTolerance(0.asMegaWattHour)
+
+          case (uuid, time, qDot, energy)
+              if uuid == littleDomesticHotWaterStorageInput.getUuid =>
+            time shouldBe 0.toDateTime
+            qDot should equalWithTolerance(-0.005405957260274.asMegaWatt)
+            energy should equalWithTolerance(0.000522.asMegaWattHour)
         }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(45)))
@@ -297,36 +288,26 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(45)
 
+      val events45 = resultServiceProxy.receiveMessages(3)
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events45 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 45)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(hpResult) =>
-            hpResult.getInputModel shouldBe typicalHpInputModel.getUuid
-            hpResult.getTime shouldBe 45.toDateTime
-            hpResult.getP should equalWithTolerance(pRunningHp)
-            hpResult.getQ should equalWithTolerance(qRunningHp)
-          case ResultEvent.ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 45.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.0004544255342.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events45.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 45.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 45.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.0004544255342.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(3416)))
 
@@ -340,47 +321,31 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(3416)
 
-      resultServiceProxy.expectMessage(
-        ExpectResult(typicalHpInputModel.getUuid, 3416)
-      )
+      val events3416 = resultServiceProxy.receiveMessages(4)
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 3416.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 3416.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.68.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 3416.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.01044.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events3416 should contain(ExpectResult(typicalHpInputModel.getUuid, 3416))
+
+      events3416.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 3416.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 3416.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.68.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          time shouldBe 3416.toDateTime
+          inputModel shouldBe typicalHeatStorage.getUuid
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.01044.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(3600)))
 
@@ -411,39 +376,24 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.expectMessage(
-        ExpectResult(typicalHpInputModel.getUuid, 3600)
-      )
+      val events3600 = resultServiceProxy.receiveMessages(3)
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(hpResult) =>
-            hpResult.getInputModel shouldBe typicalHpInputModel.getUuid
-            hpResult.getTime shouldBe 3600.toDateTime
-            hpResult.getP should equalWithTolerance(pRunningHp)
-            hpResult.getQ should equalWithTolerance(
-              qRunningHp
-            )
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 3600.toDateTime
-                qDot should equalWithTolerance(-0.005405957260273974.asMegaWatt)
-                energy should equalWithTolerance(
-                  0.00045442553424658.asMegaWattHour
-                )
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events3600 should contain(ExpectResult(typicalHpInputModel.getUuid, 3600))
+
+      events3600.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 3600.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 3600.toDateTime
+          qDot should equalWithTolerance(-0.005405957260273974.asMegaWatt)
+          energy should equalWithTolerance(0.00045442553424658.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(3625)))
 
@@ -457,37 +407,24 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(3625)
 
-      resultServiceProxy.expectMessage(
-        ExpectResult(typicalHpInputModel.getUuid, 3625)
-      )
+      val events3625 = resultServiceProxy.receiveMessages(3)
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(hpResult) =>
-            hpResult.getInputModel shouldBe typicalHpInputModel.getUuid
-            hpResult.getTime shouldBe 3625.toDateTime
-            hpResult.getP should equalWithTolerance(pRunningHp)
-            hpResult.getQ should equalWithTolerance(
-              qRunningHp
-            )
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 3625.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.00041688416.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events3625 should contain(ExpectResult(typicalHpInputModel.getUuid, 3625))
+
+      events3625.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 3625.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 3625.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.00041688416.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(4412)))
 
@@ -501,37 +438,24 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(4412)
 
-      resultServiceProxy.expectMessage(
-        ExpectResult(typicalHpInputModel.getUuid, 4412)
-      )
+      val events4412 = resultServiceProxy.receiveMessages(3)
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 4412.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 4412.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
-            }
-        }
+      events4412 should contain(ExpectResult(typicalHpInputModel.getUuid, 4412))
+
+      events4412.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 4412.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 4412.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(7200)))
 
@@ -578,36 +502,26 @@ class ThermalGridIT
           Some(25000),
         )
       }
+      val events21600 = resultServiceProxy.receiveMessages(3)
 
-      resultServiceProxy.expectMessage(
+      events21600 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 21600)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(hpResult) =>
-            hpResult.getInputModel shouldBe typicalHpInputModel.getUuid
-            hpResult.getTime shouldBe 21600.toDateTime
-            hpResult.getP should equalWithTolerance(0.asMegaWatt)
-            hpResult.getQ should equalWithTolerance(0.asMegaVar)
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 21600.toDateTime
-                qDot should equalWithTolerance(-0.005497583655.asMegaWatt)
-                energy should equalWithTolerance(0.00034555556.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events21600.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 21600.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 21600.toDateTime
+          qDot should equalWithTolerance(-0.005497583655.asMegaWatt)
+          energy should equalWithTolerance(0.00034555556.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(21659)))
 
@@ -621,38 +535,29 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(21659)
 
+      val events21659 = resultServiceProxy.receiveMessages(3)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events21659 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 21659)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(hpResult) =>
-            hpResult.getInputModel shouldBe typicalHpInputModel.getUuid
-            hpResult.getTime shouldBe 21659.toDateTime
-            hpResult.getP should equalWithTolerance(0.asMegaWatt)
-            hpResult.getQ should equalWithTolerance(0.asMegaVar)
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 21659.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(
-                  0.00025545627397260273.asMegaWattHour
-                )
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events21659.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 21659.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 21659.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(
+            0.00025545627397260273.asMegaWattHour
+          )
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(23288)))
 
@@ -666,47 +571,33 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(23288)
 
-      resultServiceProxy.expectMessage(
+      val events23288 = resultServiceProxy.receiveMessages(4)
+
+      events23288 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 23288)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 23288.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 23288.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(18.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 23288.toDateTime
-                qDot should equalWithTolerance(-0.011.asMegaWatt)
-                energy should equalWithTolerance(0.01044.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events23288.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 23288.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 23288.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(18.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 23288.toDateTime
+          qDot should equalWithTolerance(-0.011.asMegaWatt)
+          energy should equalWithTolerance(0.01044.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(25000)))
 
@@ -737,16 +628,18 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.expectMessage(
+      val events25000 = resultServiceProxy.receiveMessages(2)
+
+      events25000 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 25000)
       )
 
-      resultServiceProxy.expectMessageType[ResultEvent] match {
-        case ParticipantResultEvent(hpResult) =>
-          hpResult.getInputModel shouldBe typicalHpInputModel.getUuid
-          hpResult.getTime shouldBe 25000.toDateTime
-          hpResult.getP should equalWithTolerance(0.asMegaWatt)
-          hpResult.getQ should equalWithTolerance(0.asMegaVar)
+      events25000.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 25000.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
       }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(25200)))
@@ -761,39 +654,27 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(25200)
 
+      val events25200 = resultServiceProxy.receiveMessages(3)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events25200 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 25200)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 25200.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 25200.toDateTime
-                qDot should equalWithTolerance(-0.00547586188.asMegaWatt)
-                energy should equalWithTolerance(0.000255456274.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events25200.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 25200.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 25200.toDateTime
+          qDot should equalWithTolerance(-0.00547586188.asMegaWatt)
+          energy should equalWithTolerance(0.000255456274.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(25316)))
 
@@ -807,39 +688,27 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(25316)
 
+      val events25316 = resultServiceProxy.receiveMessages(3)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events25316 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 25316)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 25316.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 25316.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.000079011836.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events25316.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 25316.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 25316.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.000079011836.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(26704)))
 
@@ -853,37 +722,26 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(26704)
 
-      resultServiceProxy.expectMessage(
+      val events26704 = resultServiceProxy.receiveMessages(3)
+
+      events26704 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 26704)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 26704.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 26704.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events26704.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 26704.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 26704.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(28000)))
 
@@ -914,16 +772,18 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.expectMessage(
+      val events28000 = resultServiceProxy.receiveMessages(2)
+
+      events28000 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 28000)
       )
 
-      resultServiceProxy.expectMessageType[ParticipantResultEvent] match {
-        case ParticipantResultEvent(hpResult) =>
-          hpResult.getInputModel shouldBe typicalHpInputModel.getUuid
-          hpResult.getTime shouldBe 28000.toDateTime
-          hpResult.getP should equalWithTolerance(pRunningHp)
-          hpResult.getQ should equalWithTolerance(qRunningHp)
+      events28000.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 28000.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
       }
 
       // Since this activation is caused by new weather data, we don't expect any
@@ -942,41 +802,29 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(28800)
 
+      val events28800 = resultServiceProxy.receiveMessages(3)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events28800 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 28800)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 28800.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 28800.toDateTime
-                qDot should equalWithTolerance(-0.0054700501581.asMegaWatt)
-                energy should equalWithTolerance(
-                  0.00007901183561643826.asMegaWattHour
-                )
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events28800.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 28800.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 28800.toDateTime
+          qDot should equalWithTolerance(-0.0054700501581.asMegaWatt)
+          energy should equalWithTolerance(
+            0.00007901183561643826.asMegaWattHour
+          )
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(28852)))
 
@@ -990,49 +838,33 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(28852)
 
+      val events28852 = resultServiceProxy.receiveMessages(4)
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events28852 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 28852)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 28852.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 28852.toDateTime
-                qDot should equalWithTolerance(0.0055.asMegaWatt)
-                indoorTemp should equalWithTolerance(18.94.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 28852.toDateTime
-                qDot should equalWithTolerance(0.0055.asMegaWatt)
-                energy should equalWithTolerance(0.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events28852.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 28852.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 28852.toDateTime
+          qDot should equalWithTolerance(0.0055.asMegaWatt)
+          indoorTemp should equalWithTolerance(18.94.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 28852.toDateTime
+          qDot should equalWithTolerance(0.0055.asMegaWatt)
+          energy should equalWithTolerance(0.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(29193)))
 
@@ -1046,49 +878,34 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(29193)
 
+      val events29193 = resultServiceProxy.receiveMessages(4)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events29193 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 29193)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 29193.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 29193.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 29193.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.000522.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events29193.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 29193.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 29193.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 29193.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.000522.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(32032)))
 
@@ -1102,48 +919,34 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(32032)
 
+      val events32032 = resultServiceProxy.receiveMessages(4)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events32032 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 32032)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 32032.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 32032.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 32032.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                energy should equalWithTolerance(0.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events32032.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 32032.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 32032.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 32032.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          energy should equalWithTolerance(0.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(32400)))
 
@@ -1157,39 +960,27 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(32400)
 
+      val events32400 = resultServiceProxy.receiveMessages(3)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events32400 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 32400)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 32400.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 32400.toDateTime
-                qDot should equalWithTolerance(-0.005463467444.asMegaWatt)
-                energy should equalWithTolerance(0.000522.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events32400.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 32400.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 32400.toDateTime
+          qDot should equalWithTolerance(-0.005463467444.asMegaWatt)
+          energy should equalWithTolerance(0.000522.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(32541)))
 
@@ -1203,39 +994,27 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(32541)
 
+      val events32541 = resultServiceProxy.receiveMessages(3)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events32541 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 32541)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 32541.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 32541.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.0003080141917.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events32541.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 32541.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe littleDomesticHotWaterStorageInput.getUuid
+          time shouldBe 32541.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.0003080141917.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(35448)))
 
@@ -1249,48 +1028,34 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(35448)
 
+      val events35448 = resultServiceProxy.receiveMessages(4)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events35448 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 35448)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 35448.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 35448.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.81.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 35448.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.01044.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events35448.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 35448.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 35448.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.81.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 35448.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.01044.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(35983)))
 
@@ -1304,39 +1069,26 @@ class ThermalGridIT
        */
       heatPumpAgent ! Activation(35983)
 
+      val events35983 = resultServiceProxy.receiveMessages(3)
+
       // we receive update messages, since a new set point was provided
-      resultServiceProxy.expectMessage(
+      events35983 should contain(
         ExpectResult(typicalHpInputModel.getUuid, 35983)
       )
-
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 35983.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 35983.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(20.asDegreeCelsius)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events35983.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 35983.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 35983.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(20.asDegreeCelsius)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(36000)))
     }
@@ -1950,7 +1702,9 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      val events = resultServiceProxy.receiveMessages(7)
+
+      events should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 5400, true),
         ExpectResult(pvInput.getUuid, 5400, true),
@@ -1959,38 +1713,25 @@ class ThermalGridIT
         ExpectResult(pvInput.getUuid, 5400)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 5400.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 5400.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 5400.toDateTime
-                qDot should equalWithTolerance(-0.011.asMegaWatt)
-                energy should equalWithTolerance(0.01044.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      events.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 5400.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 5400.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) if inputModel == typicalHeatStorage.getUuid =>
+          time shouldBe 5400.toDateTime
+          qDot should equalWithTolerance(-0.011.asMegaWatt)
+          energy should equalWithTolerance(0.01044.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(6731)))
 

--- a/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
@@ -253,27 +253,19 @@ class ThermalGridIT
           time shouldBe 0.toDateTime
           qDot should equalWithTolerance(0.asMegaWatt)
           indoorTemp should equalWithTolerance(20.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) if inputModel == typicalHeatStorage.getUuid =>
+          time shouldBe 0.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          energy should equalWithTolerance(0.asMegaWattHour)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) if inputModel == littleDomesticHotWaterStorageInput.getUuid =>
+          time shouldBe 0.toDateTime
+          qDot should equalWithTolerance(-0.005405957260274.asMegaWatt)
+          energy should equalWithTolerance(0.000522.asMegaWattHour)
       }
-
-      events0
-        .collect {
-          case ThermalResultEvent(
-                AbstractThermalStorageResult(time, inputModel, qDot, energy)
-              ) =>
-            (inputModel, time, qDot, energy)
-        }
-        .foreach {
-          case (uuid, time, qDot, energy)
-              if uuid == typicalHeatStorage.getUuid =>
-            time shouldBe 0.toDateTime
-            qDot should equalWithTolerance(0.011.asMegaWatt)
-            energy should equalWithTolerance(0.asMegaWattHour)
-          case (uuid, time, qDot, energy)
-              if uuid == littleDomesticHotWaterStorageInput.getUuid =>
-            time shouldBe 0.toDateTime
-            qDot should equalWithTolerance(-0.005405957260274.asMegaWatt)
-            energy should equalWithTolerance(0.000522.asMegaWattHour)
-        }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(heatPumpAgent, Some(45)))
 
@@ -1320,27 +1312,19 @@ class ThermalGridIT
           time shouldBe 0.toDateTime
           qDot should equalWithTolerance(0.asMegaWatt)
           indoorTemp should equalWithTolerance(20.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) if inputModel == typicalHeatStorage.getUuid =>
+          time shouldBe 0.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.asMegaWattHour)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
+          time shouldBe 0.toDateTime
+          qDot should equalWithTolerance(-0.005496056547945205.asMegaWatt)
+          energy should equalWithTolerance(0.00149814.asMegaWattHour)
       }
-
-      msg0
-        .collect {
-          case ThermalResultEvent(
-                AbstractThermalStorageResult(time, inputModel, qDot, energy)
-              ) =>
-            (inputModel, time, qDot, energy)
-        }
-        .foreach {
-          case (uuid, time, qDot, energy)
-              if uuid == typicalHeatStorage.getUuid =>
-            time shouldBe 0.toDateTime
-            qDot should equalWithTolerance(0.asMegaWatt)
-            energy should equalWithTolerance(0.asMegaWattHour)
-          case (uuid, time, qDot, energy)
-              if uuid == smallDomesticHotWaterStorageInput.getUuid =>
-            time shouldBe 0.toDateTime
-            qDot should equalWithTolerance(-0.005496056547945205.asMegaWatt)
-            energy should equalWithTolerance(0.00149814.asMegaWattHour)
-        }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(150)))
 

--- a/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
@@ -268,7 +268,6 @@ class ThermalGridIT
             time shouldBe 0.toDateTime
             qDot should equalWithTolerance(0.011.asMegaWatt)
             energy should equalWithTolerance(0.asMegaWattHour)
-
           case (uuid, time, qDot, energy)
               if uuid == littleDomesticHotWaterStorageInput.getUuid =>
             time shouldBe 0.toDateTime
@@ -1292,7 +1291,9 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      val msg0 = resultServiceProxy.receiveMessages(9)
+
+      msg0 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 0, true),
         ExpectResult(pvInput.getUuid, 0, true),
@@ -1301,56 +1302,44 @@ class ThermalGridIT
         ExpectResult(pvInput.getUuid, 0)
       )
 
-      Range(0, 5)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
+      msg0.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 0.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 0.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 0.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(20.asDegreeCelsius)
+      }
+
+      msg0
+        .collect {
+          case ThermalResultEvent(
+                AbstractThermalStorageResult(time, inputModel, qDot, energy)
+              ) =>
+            (inputModel, time, qDot, energy)
         }
         .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 0.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 0.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 0.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(20.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 0.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.asMegaWattHour)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 0.toDateTime
-                qDot should equalWithTolerance(-0.005496056547945205.asMegaWatt)
-                energy should equalWithTolerance(0.00149814.asMegaWattHour)
-            }
+          case (uuid, time, qDot, energy)
+              if uuid == typicalHeatStorage.getUuid =>
+            time shouldBe 0.toDateTime
+            qDot should equalWithTolerance(0.asMegaWatt)
+            energy should equalWithTolerance(0.asMegaWattHour)
+          case (uuid, time, qDot, energy)
+              if uuid == smallDomesticHotWaterStorageInput.getUuid =>
+            time shouldBe 0.toDateTime
+            qDot should equalWithTolerance(-0.005496056547945205.asMegaWatt)
+            energy should equalWithTolerance(0.00149814.asMegaWattHour)
         }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(150)))
@@ -1366,47 +1355,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(150)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg150 = resultServiceProxy.receiveMessages(5)
+
+      msg150 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 150, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 150)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 150.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 150.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 150.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.0012691376438.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg150.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 150.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 150.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 150.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.0012691376438.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(1800)))
 
@@ -1439,55 +1415,41 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg1800 = resultServiceProxy.receiveMessages(7)
+
+      msg1800 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 1800, true),
+        ExpectResult(pvInput.getUuid, 1800, true),
         // expect messages due to new set point
-        ExpectResult(typicalHpInputModel.getUuid, 1800)
+        ExpectResult(typicalHpInputModel.getUuid, 1800),
+        ExpectResult(pvInput.getUuid, 1800)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 1800.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 1800.toDateTime
-                emResult._3 should equalWithTolerance(
-                  -0.002517561515.asMegaWatt
-                )
-                emResult._4 should equalWithTolerance(
-                  -0.00082748245392177.asMegaVar
-                )
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 1800.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                energy should equalWithTolerance(0.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg1800.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 1800.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 1800.toDateTime
+          p should equalWithTolerance(-0.002517561515.asMegaWatt)
+          q should equalWithTolerance(-0.00082748245392177.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 1800.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          energy should equalWithTolerance(0.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(3600)))
 
       /* TICK 3600
-      DomesticHotWaterStorage will serve the water demand of the house
+      DomesticHotWaterStorage will serve the water demand of the house.
       House demand heating : requiredDemand = 0.0 kWh, possibleDemand = 2.5 kWh
       House demand water   : requiredDemand = 0.23 kWh, possibleDemand = 0.23 kWh
       HeatStorage          : requiredDemand = 0.0 kWh, possibleDemand = 4.9 kWh
@@ -1496,53 +1458,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(3600)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg3600 = resultServiceProxy.receiveMessages(5)
+
+      msg3600 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 3600, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 3600)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 3600.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 3600.toDateTime
-                emResult._3 should equalWithTolerance(
-                  -0.002517561515.asMegaWatt
-                )
-                emResult._4 should equalWithTolerance(
-                  -0.00082748245392177.asMegaVar
-                )
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 3600.toDateTime
-                qDot should equalWithTolerance(-0.005496056547945205.asMegaWatt)
-                energy should equalWithTolerance(
-                  0.0012691376438356.asMegaWattHour
-                )
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg3600.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 3600.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 3600.toDateTime
+          p should equalWithTolerance(-0.002517561515.asMegaWatt)
+          q should equalWithTolerance(-0.00082748245392177.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 3600.toDateTime
+          qDot should equalWithTolerance(-0.005496056547945205.asMegaWatt)
+          energy should equalWithTolerance(0.0012691376438356.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(3750)))
 
@@ -1557,47 +1500,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(3750)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg3750 = resultServiceProxy.receiveMessages(5)
+
+      msg3750 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 3750, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 3750)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 3750.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 3750.toDateTime
-                emResult._3 should equalWithTolerance(-0.00251756152.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.00082748245.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 3750.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.001040135288.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg3750.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 3750.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 3750.toDateTime
+          p should equalWithTolerance(-0.00251756152.asMegaWatt)
+          q should equalWithTolerance(-0.00082748245.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 3750.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.001040135288.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(5216)))
 
@@ -1612,65 +1542,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(5216)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg5216 = resultServiceProxy.receiveMessages(6)
+
+      msg5216 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 5216, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 5216)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 5216.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 5216.toDateTime
-                emResult._3 should equalWithTolerance(-0.00251756152.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.00082748245.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 5216.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.52.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 5216.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.01044.asMegaWattHour)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 5216.toDateTime
-                qDot should equalWithTolerance(-0.010971095671.asMegaWatt)
-                energy should equalWithTolerance(0.001269575507.asMegaWattHour)
-            }
-        }
+      msg5216.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 5216.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 5216.toDateTime
+          p should equalWithTolerance(-0.00251756152.asMegaWatt)
+          q should equalWithTolerance(-0.00082748245.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 5216.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.52.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 5216.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.01044.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(5400)))
 
@@ -1702,9 +1608,9 @@ class ThermalGridIT
         )
       }
 
-      val events = resultServiceProxy.receiveMessages(7)
+      val msg5400 = resultServiceProxy.receiveMessages(7)
 
-      events should contain allOf (
+      msg5400 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 5400, true),
         ExpectResult(pvInput.getUuid, 5400, true),
@@ -1713,7 +1619,7 @@ class ThermalGridIT
         ExpectResult(pvInput.getUuid, 5400)
       )
 
-      events.collect {
+      msg5400.collect {
         case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
           uuid shouldBe typicalHpInputModel.getUuid
           time shouldBe 5400.toDateTime
@@ -1724,10 +1630,10 @@ class ThermalGridIT
           time shouldBe 5400.toDateTime
           p should equalWithTolerance(0.asMegaWatt)
           q should equalWithTolerance(0.asMegaVar)
-
         case ThermalResultEvent(
               AbstractThermalStorageResult(time, inputModel, qDot, energy)
-            ) if inputModel == typicalHeatStorage.getUuid =>
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
           time shouldBe 5400.toDateTime
           qDot should equalWithTolerance(-0.011.asMegaWatt)
           energy should equalWithTolerance(0.01044.asMegaWattHour)
@@ -1746,60 +1652,46 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(6731)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg6731 = resultServiceProxy.receiveMessages(6)
+
+      msg6731 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 6731, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 6731)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 6731.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 6731.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 6731.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 6731.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.0063730555556.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg6731.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 6731.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 6731.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 6731.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 6731.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.0063730555556.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(7200)))
 
       /* TICK 7200
-     DomesticHotWaterStorage will serve the water demand of the house
+     DomesticHotWaterStorage will serve the water demand of the house.
      House demand heating : requiredDemand = 0.0 kWh, possibleDemand = 0.32 kWh
      House demand water   : requiredDemand = 0.24 kWh, possibleDemand = 0.24 kWh
      HeatStorage          : requiredDemand = 0.0 kWh, possibleDemand = 4.07 kWh
@@ -1808,46 +1700,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(7200)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg7200 = resultServiceProxy.receiveMessages(5)
+
+      msg7200 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 7200, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 7200)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 7200.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 7200.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 7200.toDateTime
-                qDot should equalWithTolerance(-0.00549315011931065.asMegaWatt)
-                energy should equalWithTolerance(0.001040135288.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg7200.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 7200.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 7200.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 5216.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.52.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 7200.toDateTime
+          qDot should equalWithTolerance(-0.00549315011931065.asMegaWatt)
+          energy should equalWithTolerance(0.001040135288.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(7355)))
 
@@ -1861,46 +1748,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(7355)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg7355 = resultServiceProxy.receiveMessages(5)
+
+      msg7355 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 7355, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 7355)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 7355.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 7355.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 7355.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.0008036246575.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg7355.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 7355.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 7355.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 7355.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.0008036246575.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(9200)))
 
@@ -1932,7 +1807,9 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      val msg9200 = resultServiceProxy.receiveMessages(7)
+
+      msg9200 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 9200, true),
         ExpectResult(pvInput.getUuid, 9200, true),
@@ -1941,38 +1818,25 @@ class ThermalGridIT
         ExpectResult(pvInput.getUuid, 9200)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 9200.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 9200.toDateTime
-                emResult._3 should equalWithTolerance(-0.00135279808.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.00044464323.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 9200.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                energy should equalWithTolerance(0.0063730555556.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg9200.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 9200.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 9200.toDateTime
+          p should equalWithTolerance(-0.00135279808.asMegaWatt)
+          q should equalWithTolerance(-0.00044464323.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 9200.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          energy should equalWithTolerance(0.0063730555556.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(10531)))
 
@@ -1987,55 +1851,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(10531)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg10531 = resultServiceProxy.receiveMessages(6)
+
+      msg10531 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 10531, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 10531)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 10531.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 10531.toDateTime
-                emResult._3 should equalWithTolerance(-0.00135279808.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.00044464323.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 10531.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.65.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 10531.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.01044.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg10531.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 10531.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 10531.toDateTime
+          p should equalWithTolerance(-0.00135279808.asMegaWatt)
+          q should equalWithTolerance(-0.00044464323.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 10531.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.65.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 10531.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.01044.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(10800)))
 
@@ -2049,50 +1899,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(10800)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg10800 = resultServiceProxy.receiveMessages(5)
+
+      msg10800 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 10800, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 10800)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 10800.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 10800.toDateTime
-                emResult._3 should equalWithTolerance(
-                  -0.0013527980811.asMegaWatt
-                )
-                emResult._4 should equalWithTolerance(
-                  -0.0004446432268.asMegaVar
-                )
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 10800.toDateTime
-                qDot should equalWithTolerance(-0.005474387099011617.asMegaWatt)
-                energy should equalWithTolerance(0.000803624658.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg10800.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 10800.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 10800.toDateTime
+          p should equalWithTolerance(-0.0013527980811.asMegaWatt)
+          q should equalWithTolerance(-0.0004446432268.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 10800.toDateTime
+          qDot should equalWithTolerance(-0.005474387099011617.asMegaWatt)
+          energy should equalWithTolerance(0.000803624658.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(10958)))
 
@@ -2106,50 +1940,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(10958)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg10958 = resultServiceProxy.receiveMessages(5)
+
+      msg10958 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 10958, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 10958)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 10958.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 10958.toDateTime
-                emResult._3 should equalWithTolerance(
-                  -0.0013527980811294546.asMegaWatt
-                )
-                emResult._4 should equalWithTolerance(
-                  -0.0004446432267837181.asMegaVar
-                )
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 10958.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.00056335989.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg10958.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 10958.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 10958.toDateTime
+          p should equalWithTolerance(-0.00135279808.asMegaWatt)
+          q should equalWithTolerance(-0.00044464323.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 10958.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.00056335989.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(11638)))
 
@@ -2164,45 +1982,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(11638)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg11638 = resultServiceProxy.receiveMessages(5)
+
+      msg11638 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 11638, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 11638)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 11638.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 11638.toDateTime
-                emResult._3 should equalWithTolerance(-0.00515279808.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.00169364283.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 11638.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
-            }
-        }
+      msg11638.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 11638.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 11638.toDateTime
+          p should equalWithTolerance(-0.00515279808.asMegaWatt)
+          q should equalWithTolerance(-0.00169364283.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 11638.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(12000)))
 
@@ -2235,7 +2042,9 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      val msg12000 = resultServiceProxy.receiveMessages(7)
+
+      msg12000 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 12000, true),
         ExpectResult(pvInput.getUuid, 12000, true),
@@ -2244,38 +2053,25 @@ class ThermalGridIT
         ExpectResult(pvInput.getUuid, 12000)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 12000.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 12000.toDateTime
-                emResult._3 should equalWithTolerance(-0.001402125.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.0004608562.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 12000.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.96.asDegreeCelsius)
-            }
-        }
+      msg12000.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 12000.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 12000.toDateTime
+          p should equalWithTolerance(-0.001402125.asMegaWatt)
+          q should equalWithTolerance(-0.0004608562.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 12000.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.96.asDegreeCelsius)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(12139)))
 
@@ -2290,45 +2086,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(12139)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg12139 = resultServiceProxy.receiveMessages(5)
+
+      msg12139 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 12139, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 12139)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 12139.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 12139.toDateTime
-                emResult._3 should equalWithTolerance(-0.005202125.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.0017098558.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 12139.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(20.asDegreeCelsius)
-            }
-        }
+      msg12139.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 12139.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 12139.toDateTime
+          p should equalWithTolerance(-0.005202125.asMegaWatt)
+          q should equalWithTolerance(-0.0017098558.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 12139.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(20.asDegreeCelsius)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(12500)))
 
@@ -2361,7 +2146,9 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      val msg12500 = resultServiceProxy.receiveMessages(6)
+
+      msg12500 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 12500, true),
         ExpectResult(pvInput.getUuid, 12500, true),
@@ -2369,24 +2156,18 @@ class ThermalGridIT
         ExpectResult(typicalHpInputModel.getUuid, 12500)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach { case ParticipantResultEvent(participantResult) =>
-          participantResult match {
-            case HpResult(hpResult) =>
-              hpResult._2 shouldBe typicalHpInputModel.getUuid
-              hpResult._1 shouldBe 12500.toDateTime
-              hpResult._3 should equalWithTolerance(0.asMegaWatt)
-              hpResult._4 should equalWithTolerance(0.asMegaVar)
-            case EmResult(emResult) =>
-              emResult._2 shouldBe emInput.getUuid
-              emResult._1 shouldBe 12500.toDateTime
-              emResult._3 should equalWithTolerance(0.asMegaWatt)
-              emResult._4 should equalWithTolerance(0.asMegaVar)
-          }
-        }
+      msg12500.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 12500.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 12500.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(14400)))
 
@@ -2417,55 +2198,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(24412)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg24412 = resultServiceProxy.receiveMessages(6)
+
+      msg24412 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 24412, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 24412)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 24412.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 24412.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 24412.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(18.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 24412.toDateTime
-                qDot should equalWithTolerance(-0.011.asMegaWatt)
-                energy should equalWithTolerance(0.01044.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg24412.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 24412.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 24412.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 24412.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(18.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 24412.toDateTime
+          qDot should equalWithTolerance(-0.011.asMegaWatt)
+          energy should equalWithTolerance(0.01044.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(25200)))
 
@@ -2497,54 +2264,47 @@ class ThermalGridIT
         )
       }
 
+      val msg25200 = resultServiceProxy.receiveMessages(8)
+
       // expect messages due to flex activation
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      msg25200 should contain allOf (
         ExpectResult(typicalHpInputModel.getUuid, 25200, true),
         ExpectResult(pvInput.getUuid, 25200, true),
         ExpectResult(typicalHpInputModel.getUuid, 25200),
-        ExpectResult(pvInput.getUuid, 25200),
+        ExpectResult(pvInput.getUuid, 25200)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
+      msg25200.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 25200.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 25200.toDateTime
+          p should equalWithTolerance(-0.00055721828.asMegaWatt)
+          q should equalWithTolerance(-0.00018314879.asMegaVar)
+      }
+
+      msg25200
+        .collect {
+          case ThermalResultEvent(
+                AbstractThermalStorageResult(time, inputModel, qDot, energy)
+              ) =>
+            (inputModel, time, qDot, energy)
         }
         .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 25200.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 25200.toDateTime
-                emResult._3 should equalWithTolerance(-0.00055721828.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.00018314879.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 25200.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.0080322222222.asMegaWattHour)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 25200.toDateTime
-                qDot should equalWithTolerance(-0.00543467835616.asMegaWatt)
-                energy should equalWithTolerance(0.000045288986.asMegaWattHour)
-            }
+          case (uuid, time, qDot, energy)
+              if uuid == typicalHeatStorage.getUuid =>
+            time shouldBe 25200.toDateTime
+            qDot should equalWithTolerance(0.asMegaWatt)
+            energy should equalWithTolerance(0.0080322222222.asMegaWattHour)
+          case (uuid, time, qDot, energy)
+              if uuid == smallDomesticHotWaterStorageInput.getUuid =>
+            time shouldBe 25200.toDateTime
+            qDot should equalWithTolerance(-0.00543467835616.asMegaWatt)
+            energy should equalWithTolerance(0.000045288986.asMegaWattHour)
         }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(25230)))
@@ -2559,56 +2319,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(25230)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg25230 = resultServiceProxy.receiveMessages(6)
+
+      msg25230 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 25230, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 25230)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 25230.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 25230.toDateTime
-                emResult._3 should equalWithTolerance(-0.00055721828.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.000183148792.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 25230.toDateTime
-                qDot should equalWithTolerance(0.0055.asMegaWatt)
-                indoorTemp should equalWithTolerance(18.20.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 25230.toDateTime
-                qDot should equalWithTolerance(0.0055.asMegaWatt)
-                energy should equalWithTolerance(0.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg25230.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 25230.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 25230.toDateTime
+          p should equalWithTolerance(-0.00055721828.asMegaWatt)
+          q should equalWithTolerance(-0.000183148792.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 25230.toDateTime
+          qDot should equalWithTolerance(0.0055.asMegaWatt)
+          indoorTemp should equalWithTolerance(18.20.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 25230.toDateTime
+          qDot should equalWithTolerance(0.0055.asMegaWatt)
+          energy should equalWithTolerance(0.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(26210)))
 
@@ -2622,56 +2367,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(26210)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg26210 = resultServiceProxy.receiveMessages(6)
+
+      msg26210 should contain allOf (
         // we receive a message, since new data arrived
         ExpectResult(typicalHpInputModel.getUuid, 26210, true),
         // we receive update messages, since a new set point was provided
         ExpectResult(typicalHpInputModel.getUuid, 26210)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 26210.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 26210.toDateTime
-                emResult._3 should equalWithTolerance(-0.00055721828.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.00018314879.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 26210.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(18.32.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 26210.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.00149814.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg26210.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 26210.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 26210.toDateTime
+          p should equalWithTolerance(-0.00055721828.asMegaWatt)
+          q should equalWithTolerance(-0.00018314879.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 26210.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(18.32.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 26210.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.00149814.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(27500)))
 
@@ -2703,7 +2433,9 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      val msg27500 = resultServiceProxy.receiveMessages(6)
+
+      msg27500 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 27500, true),
         ExpectResult(pvInput.getUuid, 27500, true),
@@ -2712,24 +2444,18 @@ class ThermalGridIT
         ExpectResult(pvInput.getUuid, 27500)
       )
 
-      Range(0, 2)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach { case ParticipantResultEvent(participantResult) =>
-          participantResult match {
-            case HpResult(hpResult) =>
-              hpResult._2 shouldBe typicalHpInputModel.getUuid
-              hpResult._1 shouldBe 27500.toDateTime
-              hpResult._3 should equalWithTolerance(pRunningHp)
-              hpResult._4 should equalWithTolerance(qRunningHp)
-            case EmResult(emResult) =>
-              emResult._2 shouldBe emInput.getUuid
-              emResult._1 shouldBe 27500.toDateTime
-              emResult._3 should equalWithTolerance(-0.000063896497.asMegaWatt)
-              emResult._4 should equalWithTolerance(-0.00002100176.asMegaVar)
-          }
-        }
+      msg27500.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 27500.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 27500.toDateTime
+          p should equalWithTolerance(-0.000063896497.asMegaWatt)
+          q should equalWithTolerance(-0.00002100176.asMegaVar)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(28800)))
 
@@ -2743,46 +2469,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(28800)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg28800 = resultServiceProxy.receiveMessages(5)
+
+      msg28800 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 28800, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 28800)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 28800.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 28800.toDateTime
-                emResult._3 should equalWithTolerance(-0.0000638965.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.000021001763.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 28800.toDateTime
-                qDot should equalWithTolerance(-0.0054634674439.asMegaWatt)
-                energy should equalWithTolerance(0.00149814.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg28800.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 28800.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 28800.toDateTime
+          p should equalWithTolerance(-0.0000638965.asMegaWatt)
+          q should equalWithTolerance(-0.000021001763.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 28800.toDateTime
+          qDot should equalWithTolerance(-0.0054634674439.asMegaWatt)
+          energy should equalWithTolerance(0.00149814.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(28941)))
 
@@ -2796,46 +2510,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(28941)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg28941 = resultServiceProxy.receiveMessages(5)
+
+      msg28941 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 28941, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 28941)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 28941.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 28941.toDateTime
-                emResult._3 should equalWithTolerance(-0.0000638965.asMegaWatt)
-                emResult._4 should equalWithTolerance(-0.000021001763.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 28941.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.001284154192.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg28941.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 28941.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 28941.toDateTime
+          p should equalWithTolerance(-0.0000638965.asMegaWatt)
+          q should equalWithTolerance(-0.000021001763.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 28941.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.001284154192.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(31000)))
 
@@ -2867,51 +2569,36 @@ class ThermalGridIT
           Some(46800),
         )
       }
+      val msg31000 = resultServiceProxy.receiveMessages(7)
 
       // expect messages due to flex activation
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      msg31000 should contain allOf (
         ExpectResult(typicalHpInputModel.getUuid, 31000, true),
-        ExpectResult(pvInput.getUuid, 31000, true)
-      )
-
-      // expect messages due to new set point
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+        ExpectResult(pvInput.getUuid, 31000, true),
+        // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 31000),
         ExpectResult(pvInput.getUuid, 31000)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 31000.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 31000.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 31000.toDateTime
-                qDot should equalWithTolerance(-0.011.asMegaWatt)
-                energy should equalWithTolerance(0.00803222222.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg31000.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 31000.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 31000.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 31000.toDateTime
+          qDot should equalWithTolerance(-0.011.asMegaWatt)
+          energy should equalWithTolerance(0.00803222222.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(31762)))
 
@@ -2926,56 +2613,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(31762)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg31762 = resultServiceProxy.receiveMessages(6)
+
+      msg31762 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 31762, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 31762)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 31762.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 31762.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 31762.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 31762.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.0057038888889.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg31762.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 31762.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 31762.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 31762.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(19.99.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 31762.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.0057038888889.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(32400)))
 
@@ -3007,55 +2679,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(41762)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg41762 = resultServiceProxy.receiveMessages(6)
+
+      msg41762 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 41762, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 41762)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 41762.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 41762.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 41762.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(18.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 41762.toDateTime
-                qDot should equalWithTolerance(-0.011.asMegaWatt)
-                energy should equalWithTolerance(0.005703888889.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg41762.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 41762.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 41762.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 41762.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(18.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 41762.toDateTime
+          qDot should equalWithTolerance(-0.011.asMegaWatt)
+          energy should equalWithTolerance(0.005703888889.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(43200)))
 
@@ -3085,46 +2743,34 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(43311)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg43311 = resultServiceProxy.receiveMessages(5)
+
+      msg43311 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 43311, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 43311)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 43311.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 43311.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 43311.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.0004056861.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg43311.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 43311.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 43311.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 43311.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.0004056861.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(43628)))
 
@@ -3141,55 +2787,41 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(43628)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg43628 = resultServiceProxy.receiveMessages(6)
+
+      msg43628 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 43628, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 43628)
       )
 
-      Range(0, 4)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 43628.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 43628.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 43628.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(18.39.asDegreeCelsius)
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  ) if inputModel == typicalHeatStorage.getUuid =>
-                time shouldBe 43628.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                energy should equalWithTolerance(0.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg43628.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 43628.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 43628.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 43628.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(18.39.asDegreeCelsius)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe typicalHeatStorage.getUuid
+          time shouldBe 43628.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          energy should equalWithTolerance(0.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(45620)))
 
@@ -3204,45 +2836,35 @@ class ThermalGridIT
        */
       emAgentActivation ! Activation(45620)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg45620 = resultServiceProxy.receiveMessages(5)
+
+      msg45620 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 45620, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 45620)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 45620.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 45620.toDateTime
-                emResult._3 should equalWithTolerance(pRunningHp)
-                emResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 45620.toDateTime
-                qDot should equalWithTolerance(0.011.asMegaWatt)
-                indoorTemp should equalWithTolerance(18.asDegreeCelsius)
-            }
-        }
+      msg45620.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 45620.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 45620.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 45620.toDateTime
+          qDot should equalWithTolerance(0.011.asMegaWatt)
+          indoorTemp should equalWithTolerance(18.asDegreeCelsius)
+      }
+
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(46800)))
 
@@ -3271,7 +2893,9 @@ class ThermalGridIT
         )
       }
 
-      resultServiceProxy.receiveMessages(4) should contain allOf (
+      val msg46800 = resultServiceProxy.receiveMessages(7)
+
+      msg46800 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 46800, true),
         ExpectResult(pvInput.getUuid, 46800, true),
@@ -3280,39 +2904,25 @@ class ThermalGridIT
         ExpectResult(pvInput.getUuid, 46800)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 46800.toDateTime
-                hpResult._3 should equalWithTolerance(pRunningHp)
-                hpResult._4 should equalWithTolerance(qRunningHp)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 46800.toDateTime
-                emResult._3 should equalWithTolerance(pRunningHp)
-                emResult._4 should equalWithTolerance(qRunningHp)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case AbstractThermalStorageResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    energy,
-                  )
-                  if inputModel == smallDomesticHotWaterStorageInput.getUuid =>
-                time shouldBe 46800.toDateTime
-                qDot should equalWithTolerance(-0.005474387099.asMegaWatt)
-                energy should equalWithTolerance(0.000405686137.asMegaWattHour)
-              case _ => fail("Unexpected thermal unit result")
-            }
-        }
+      msg46800.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 46800.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 46800.toDateTime
+          p should equalWithTolerance(pRunningHp)
+          q should equalWithTolerance(qRunningHp)
+        case ThermalResultEvent(
+              AbstractThermalStorageResult(time, inputModel, qDot, energy)
+            ) =>
+          inputModel shouldBe smallDomesticHotWaterStorageInput.getUuid
+          time shouldBe 46800.toDateTime
+          qDot should equalWithTolerance(-0.005474387099.asMegaWatt)
+          energy should equalWithTolerance(0.000405686137.asMegaWattHour)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(46879)))
 
@@ -3343,45 +2953,34 @@ class ThermalGridIT
 
       emAgentActivation ! Activation(55263)
 
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      val msg55263 = resultServiceProxy.receiveMessages(5)
+
+      msg55263 should contain allOf (
         // expect messages due to flex activation
         ExpectResult(typicalHpInputModel.getUuid, 55263, true),
         // expect messages due to new set point
         ExpectResult(typicalHpInputModel.getUuid, 55263)
       )
 
-      Range(0, 3)
-        .map { _ =>
-          resultServiceProxy.expectMessageType[ResultEvent]
-        }
-        .foreach {
-          case ParticipantResultEvent(participantResult) =>
-            participantResult match {
-              case HpResult(hpResult) =>
-                hpResult._2 shouldBe typicalHpInputModel.getUuid
-                hpResult._1 shouldBe 55263.toDateTime
-                hpResult._3 should equalWithTolerance(0.asMegaWatt)
-                hpResult._4 should equalWithTolerance(0.asMegaVar)
-              case EmResult(emResult) =>
-                emResult._2 shouldBe emInput.getUuid
-                emResult._1 shouldBe 55263.toDateTime
-                emResult._3 should equalWithTolerance(0.asMegaWatt)
-                emResult._4 should equalWithTolerance(0.asMegaVar)
-            }
-          case ThermalResultEvent(thermalUnitResult) =>
-            thermalUnitResult match {
-              case ThermalHouseResult(
-                    time,
-                    inputModel,
-                    qDot,
-                    indoorTemp,
-                  ) =>
-                inputModel shouldBe typicalThermalHouse.getUuid
-                time shouldBe 55263.toDateTime
-                qDot should equalWithTolerance(0.asMegaWatt)
-                indoorTemp should equalWithTolerance(20.asDegreeCelsius)
-            }
-        }
+      msg55263.collect {
+        case ParticipantResultEvent(HpResult(time, uuid, p, q)) =>
+          uuid shouldBe typicalHpInputModel.getUuid
+          time shouldBe 55263.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ParticipantResultEvent(EmResult(time, uuid, p, q)) =>
+          uuid shouldBe emInput.getUuid
+          time shouldBe 55263.toDateTime
+          p should equalWithTolerance(0.asMegaWatt)
+          q should equalWithTolerance(0.asMegaVar)
+        case ThermalResultEvent(
+              ThermalHouseResult(time, inputModel, qDot, indoorTemp)
+            ) =>
+          inputModel shouldBe typicalThermalHouse.getUuid
+          time shouldBe 55263.toDateTime
+          qDot should equalWithTolerance(0.asMegaWatt)
+          indoorTemp should equalWithTolerance(20.asDegreeCelsius)
+      }
       resultServiceProxy.expectNoMessage()
       scheduler.expectMessage(Completion(emAgentActivation, Some(57600)))
     }

--- a/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/grid/ThermalGridIT.scala
@@ -2498,15 +2498,11 @@ class ThermalGridIT
       }
 
       // expect messages due to flex activation
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+      resultServiceProxy.receiveMessages(4) should contain allOf (
         ExpectResult(typicalHpInputModel.getUuid, 25200, true),
-        ExpectResult(pvInput.getUuid, 25200, true)
-      )
-
-      // expect messages due to new set point
-      resultServiceProxy.receiveMessages(2) should contain allOf (
+        ExpectResult(pvInput.getUuid, 25200, true),
         ExpectResult(typicalHpInputModel.getUuid, 25200),
-        ExpectResult(pvInput.getUuid, 25200)
+        ExpectResult(pvInput.getUuid, 25200),
       )
 
       Range(0, 4)

--- a/src/test/scala/edu/ie3/simona/test/common/input/EmInputTestData.scala
+++ b/src/test/scala/edu/ie3/simona/test/common/input/EmInputTestData.scala
@@ -90,8 +90,8 @@ trait EmInputTestData
 
   protected val storageInputContainer = SimpleInputContainer(storageInput)
 
-  protected val adaptedTypeInput = new HpTypeInput(
-    UUID.fromString("9802bf35-2a4e-4ff5-be9b-cd9e6a78dcd6"),
+  protected val hpTypeInputEmIT = new HpTypeInput(
+    UUID.fromString("a42f567a-f132-43d3-8b9f-2d5703673647"),
     "hp type",
     Quantities.getQuantity(0.0, StandardUnits.CAPEX),
     Quantities.getQuantity(0.0, StandardUnits.ENERGY_PRICE),
@@ -100,8 +100,8 @@ trait EmInputTestData
     Quantities.getQuantity(7.5, StandardUnits.ACTIVE_POWER_IN),
   )
 
-  protected val adaptedHpInputModel = new HpInput(
-    UUID.fromString("7832dea4-8703-4b37-8752-e67b86e957df"),
+  protected val hpInputModelEmIT = new HpInput(
+    UUID.fromString("f2d207b4-d70b-4cf0-a140-4cc76df24695"),
     "test hp",
     OperatorInput.NO_OPERATOR_ASSIGNED,
     OperationTime.notLimited(),
@@ -109,12 +109,12 @@ trait EmInputTestData
     thermalBusInput,
     ReactivePowerCharacteristic.parse("cosPhiFixed:{(0.00,0.98)}"),
     emInput,
-    adaptedTypeInput,
+    hpTypeInputEmIT,
   )
 
   /* Set inner temperature of house a bit lower */
-  val adaptedThermalHouse = new ThermalHouseInput(
-    UUID.fromString("91940626-bdd0-41cf-96dd-47c94c86b20e"),
+  val thermalHouseEmIT = new ThermalHouseInput(
+    UUID.fromString("bdd682c0-7ad2-4b06-9751-fe3051a35825"),
     "thermal house",
     thermalBusInput,
     Quantities.getQuantity(0.15, StandardUnits.THERMAL_TRANSMISSION),
@@ -125,13 +125,13 @@ trait EmInputTestData
     "house",
     2.0,
   )
-  val adaptedThermalGrid = new ThermalGrid(
+  val thermalGridEmIT = new ThermalGrid(
     thermalBusInput,
-    Seq(adaptedThermalHouse).asJava,
+    Seq(thermalHouseEmIT).asJava,
     Seq.empty[ThermalStorageInput].asJava,
     Seq[ThermalStorageInput](defaultDomesticHotWaterStorageInput).asJava,
   )
 
-  protected val adaptedWithHeatContainer =
-    WithHeatInputContainer(adaptedHpInputModel, adaptedThermalGrid)
+  protected val withHeatContainerEmIT =
+    WithHeatInputContainer(hpInputModelEmIT, thermalGridEmIT)
 }

--- a/src/test/scala/edu/ie3/simona/test/common/input/HpInputTestData.scala
+++ b/src/test/scala/edu/ie3/simona/test/common/input/HpInputTestData.scala
@@ -66,8 +66,6 @@ trait HpInputTestData extends NodeInputTestData with ThermalGridTestData {
     2.0,
   )
 
-  protected val defaultThermalHouse = ThermalHouse(defaultThermalHouseInput)
-
   protected val defaultDomesticHotWaterStorageInput =
     new DomesticHotWaterStorageInput(
       UUID.fromString("5a3935c0-14ff-4d7b-9e69-a101f41a3b73"),
@@ -115,13 +113,6 @@ trait HpInputTestData extends NodeInputTestData with ThermalGridTestData {
       Quantities.getQuantity(1.16, StandardUnits.SPECIFIC_HEAT_CAPACITY),
       Quantities.getQuantity(11.0, StandardUnits.ACTIVE_POWER_IN),
     )
-
-  protected val typicalThermalGrid = new container.ThermalGrid(
-    thermalBusInput,
-    Seq(typicalThermalHouse).asJava,
-    Set[ThermalStorageInput](typicalHeatStorage).asJava,
-    Seq[ThermalStorageInput](defaultDomesticHotWaterStorageInput).asJava,
-  )
 
   protected val typicalHpTypeInput = new HpTypeInput(
     UUID.fromString("2829d5eb-352b-40df-a07f-735b65a0a7bd"),


### PR DESCRIPTION
resolves #1757 

This changes:
- variable naming of `HpInput` and `HpTypeInput` used for `EmAgentIT`
- removes some unused inputs in `HpInputTestData`
- combines two separate result event messages evaluation in `EmAgentIT`
- restructures the evaluation of result event messages within ThermalGridIT