### PR TITLE
Fixing `ParticipantAgent.isCalculationRequired` to include `changesAtNextActivation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,10 +127,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed EVCS `OperationChangeIndiactor` in edge cases [#1762](https://github.com/ie3-institute/simona/issues/1762)
 - Fixed `AbstractEnergyBoundariesFlexModel` next tick determination [#1769](https://github.com/ie3-institute/simona/issues/1769)
 - Fixed energy limit handling in `OptimizedFlexStrat` [#1772](https://github.com/ie3-institute/simona/issues/1772)
-- Fix unreliable ThermalGridIT/EmAgentIT [#1757](https://github.com/ie3-institute/simona/issues/1757)
+- Fixed unreliable ThermalGridIT/EmAgentIT [#1757](https://github.com/ie3-institute/simona/issues/1757)
 - Cleaned imports [#1791](https://github.com/ie3-institute/simona/issues/1791)
 - Fixed hour angle calculation in `PvModel` [#574](https://github.com/ie3-institute/simona/issues/574)
 - Documentation of `PvModel` [#1776](https://github.com/ie3-institute/simona/issues/1776)
+- Fixed `ParticipantAgent.isCalculationRequired` to include `changesAtNextActivation` [#1820](https://github.com/ie3-institute/simona/issues/1820)
 
 ### Removed
 - Removed unused classes and methods related to pekko classic actors [#1389](https://github.com/ie3-institute/simona/issues/1389)

--- a/src/main/scala/edu/ie3/simona/agent/participant/ParticipantAgent.scala
+++ b/src/main/scala/edu/ie3/simona/agent/participant/ParticipantAgent.scala
@@ -437,11 +437,14 @@ object ParticipantAgent {
       modelShell: ParticipantModelShell[?, ?],
       inputHandler: DataInputHandler,
       activation: ActivationRequest,
-  ): Boolean =
+  ): Boolean = {
+    val modelIndicator = modelShell
+      .getChangeIndicator(activation.tick - 1, None)
+
     inputHandler.hasNewData(activation.tick) ||
-      modelShell
-        .getChangeIndicator(activation.tick - 1, None)
-        .changesAtTick
-        .contains(activation.tick)
+    modelIndicator.changesAtNextActivation ||
+    modelIndicator.changesAtTick
+      .contains(activation.tick)
+  }
 
 }

--- a/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
+++ b/src/test/scala/edu/ie3/simona/agent/em/EmAgentIT.scala
@@ -282,11 +282,9 @@ class EmAgentIT
           Some(14400),
         )
 
-        resultServiceProxy.receiveMessages(4) should contain allOf (
+        resultServiceProxy.receiveMessages(3) should contain allOf (
           // we receive a message, since new data arrived
           ExpectResult(pvInput.getUuid, 7200, true),
-          // expect no result, since we are still waiting for a new set point
-          NoResult(storageInput.getUuid, 7200),
           // we expect results, since we received new set points
           ExpectResult(pvInput.getUuid, 7200),
           ExpectResult(storageInput.getUuid, 7200)


### PR DESCRIPTION
Closes #1820 